### PR TITLE
__repr__ and _html_repr_ for Tracklet

### DIFF
--- a/btrack/btypes.py
+++ b/btrack/btypes.py
@@ -130,7 +130,7 @@ class PyTrackingInfo(ctypes.Structure):
             import pandas as pd
             return pd.DataFrame(self.to_dict()).to_html()
         except:
-            return "Install pandas for nicer rendering <br>" + self.__repr__()
+            return "<b>Install pandas for nicer, tabular rendering in Jupyter</b> <br>" + self.__repr__()
 
     @property
     def tracker_active(self):
@@ -349,7 +349,7 @@ class Tracklet:
             import pandas as pd
             return pd.DataFrame(self.to_dict()).to_html()
         except:
-            return "Install pandas for nicer rendering <br>" + self.__repr__()
+            return "<b>Install pandas for nicer, tabular rendering in Jupyter</b> <br>" + self.__repr__()
 
     @property
     def x(self): return [o.x for o in self._data]

--- a/btrack/btypes.py
+++ b/btrack/btypes.py
@@ -122,6 +122,16 @@ class PyTrackingInfo(ctypes.Structure):
         stats = {k:getattr(self, k) for k,typ in PyTrackingInfo._fields_}
         return stats
 
+    def __repr__(self):
+        return self.to_dict().__repr__()
+
+    def _repr_html_(self):
+        try:
+            import pandas as pd
+            return pd.DataFrame(self.to_dict()).to_html()
+        except:
+            return "Install pandas for nicer rendering <br>" + self.__repr__()
+
     @property
     def tracker_active(self):
         """ return the current status """
@@ -330,6 +340,16 @@ class Tracklet:
 
     def __len__(self):
         return len(self._data)
+
+    def __repr__(self):
+        return self.to_dict().__repr__()
+
+    def _repr_html_(self):
+        try:
+            import pandas as pd
+            return pd.DataFrame(self.to_dict()).to_html()
+        except:
+            return "Install pandas for nicer rendering <br>" + self.__repr__()
 
     @property
     def x(self): return [o.x for o in self._data]


### PR DESCRIPTION
Hi, 
I was playing with your tutorial notebook in colab and when inspecting some of the data structures I noticed that the `Tracklets` output did not provide much insight:

![image](https://user-images.githubusercontent.com/2210044/91271705-f09ede00-e7bd-11ea-8f82-322396ff5ea7.png)

So I went ahead and added `__repr__` and `_html_repr_`  methods for `Tracklet` and `PyTrackingInfo` classes. 

On a plain terminal, they will simply return the dictionary.
In Jupyter, if pandas cannot be found in the environment, they will output a message about installing pandas followed by the  dictionary:

![image](https://user-images.githubusercontent.com/2210044/91271917-45425900-e7be-11ea-8943-9d4ba13c101a.png)

Finally, if pandas is installed and we are in Jupyter, we get a nice representation of the `Tracklet` object.
![image](https://user-images.githubusercontent.com/2210044/91271329-5c347b80-e7bd-11ea-9a56-1674eaacd7f5.png)


This has only been tested interactively (no automated tests) and only for `Tracklet`. I have yet to find a `PyTrackingInfo` object in use. 
Feel free to edit or to disregard. 