### PR TITLE
add saving and loading track data documentation

### DIFF
--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -13,6 +13,7 @@ Welcome to the user guide for btrack.
    simple_example
    configuration
    napari
+   saving_tracks
    large_datasets
 ..
    Add other stuff

--- a/docs/user_guide/saving_tracks.rst
+++ b/docs/user_guide/saving_tracks.rst
@@ -1,0 +1,29 @@
+Saving and loading track data
+*****************************
+
+Tracks can be exported using the HDF5 file format, as follows:
+
+
+.. code:: python
+
+  # export tracks using the HDF5 format
+  with btrack.BayesianTracker() as tracker:
+
+    # run the tracking
+    ...
+
+    # export the data in an HDF5 file
+    tracker.export('/path/to/tracks.h5', obj_type='obj_type_1')
+
+
+
+Later, tracks can then be loaded using the inbuilt track reader, as follows:
+
+.. code:: python
+
+  with btrack.dataio.HDF5FileHandler(
+    '/path/to/tracks.h5', 'r', obj_type='obj_type_1'
+  ) as reader:
+    tracks = reader.tracks
+
+`tracks` will now be a Python list of Tracklet objects.

--- a/docs/user_guide/saving_tracks.rst
+++ b/docs/user_guide/saving_tracks.rst
@@ -26,4 +26,4 @@ Later, tracks can then be loaded using the inbuilt track reader, as follows:
   ) as reader:
     tracks = reader.tracks
 
-`tracks` will now be a Python list of Tracklet objects.
+``tracks`` will now be a Python list of Tracklet objects.


### PR DESCRIPTION
Realised that we didn't have an explanation about how to load data once it had been exported (see #71). Added this as a quick fix.

closes #72 