### PR TITLE
Use `requirements.txt` in `environment.yml` to avoid repetition

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Best done with [conda](https://github.com/conda-forge/miniforge)
 
 ```sh
 conda env create -f environment.yml
+conda activate btrack
 pip install btrack
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ BayesianTracker has been tested with Python 3.7+ on OS X, Linux and Win10.
 $ pip install btrack
 ```
 
+## Installing on M1 Mac/Apple Silicon/osx-arm64
+
+Best done with [conda](https://github.com/conda-forge/miniforge)
+
+```sh
+conda env create -f environment.yml
+pip install btrack
+```
+
 ## Usage examples
 
 Visit [btrack documentation][docs] to learn how to use it and see other examples.

--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,9 @@ name: btrack
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
-  - pip
   - cvxopt>=1.2.0
   - h5py>=2.10.0
-  - matplotlib>=3.1.1
-  - numpy>=1.17.3
-  - scipy>=1.3.1
+  - pip
+  - python=3.8
+  - pip:
+      - -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ cvxopt>=1.2.0
 h5py>=2.10.0
 matplotlib>=3.1.1
 numpy>=1.17.3
-scipy>=1.3.1
 scikit-image>=0.16.2
+scipy>=1.3.1


### PR DESCRIPTION
The start of thinking about https://github.com/quantumjot/BayesianTracker/issues/74. Ultimately it would good to be able to be able to simply `pip install btrack` but that is outside the scope of this PR

For M1 mac, one must use `conda` to install `h5py` and `cvxopt`. I've dug out my old Intel Mac and tested it with:
* creating a `conda` environment from this new `environment.yml` then installing `btrack`
* creating a `conda` environment from this new `environment.yml` with `h5py` and `cvxopt` removed from the `requirements.txt` then installing `btrack` (thus avoiding the repetition)
* create an empty `conda` environment and then running `pip install -r requirements.txt` (i.e. not using the `environment.yml` file) followed by installing `btrack`

So this change won't impact anyone on Intel Mac, but enables someone to run it on M1. The disadvantage of this currently is the repetition of `h5py`/`cvoxpt` in both `environment.yml` and `requirements.txt`