### PR TITLE
Set logger names to __name__

### DIFF
--- a/btrack/_localization.py
+++ b/btrack/_localization.py
@@ -34,7 +34,7 @@ except ImportError:
     DASK_INSTALLED = False
 
 # get the logger instance
-logger = logging.getLogger("worker_process")
+logger = logging.getLogger(__name__)
 
 
 def _centroids_from_single_arr(

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -29,7 +29,7 @@ from .optimise import optimiser
 __version__ = constants.get_version()
 
 # get the logger instance
-logger = logging.getLogger('worker_process')
+logger = logging.getLogger(__name__)
 
 # if we don't have any handlers, set one up
 if not logger.handlers:

--- a/btrack/libwrapper.py
+++ b/btrack/libwrapper.py
@@ -29,7 +29,7 @@ from .constants import BTRACK_PATH
 from .optimise import hypothesis
 
 # get the logger instance
-logger = logging.getLogger('worker_process')
+logger = logging.getLogger(__name__)
 
 
 def numpy_pointer_decorator(func):

--- a/btrack/utils.py
+++ b/btrack/utils.py
@@ -31,7 +31,7 @@ from ._localization import segmentation_to_objects
 from .models import HypothesisModel, MotionModel, ObjectModel
 
 # get the logger instance
-logger = logging.getLogger("worker_process")
+logger = logging.getLogger(__name__)
 
 
 # add an alias here


### PR DESCRIPTION
Fixes https://github.com/quantumjot/BayesianTracker/issues/51. This seems to be all the instances of `getLogger()`, and I assumed that they should all be updated.