### PR TITLE
Set documentation version from btrack version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import btrack
 
 # -- Project information -----------------------------------------------------
 
@@ -21,8 +22,9 @@ project = 'Bayesian Tracker (btrack) 🔬💻'
 copyright = '2022, Alan R Lowe'
 author = 'Alan R Lowe'
 
+
 # The full version, including alpha/beta/rc tags
-release = 'v0.4.2'
+release = 'v' + btrack.__version__
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Part of https://github.com/quantumjot/BayesianTracker/issues/70, this means one less place to manually update the version number.