### PR TITLE
Replace numpy matrix in config

### DIFF
--- a/btrack/models.py
+++ b/btrack/models.py
@@ -46,7 +46,7 @@ class MotionModel:
         Observation matrix.
     P : array (states, states)
         Initial covariance estimate.
-    G : array (states, )
+    G : array (1, states)
         Estimated error in process.
     R : array (measurements, measurements)
         Estimated error in measurements.
@@ -92,7 +92,8 @@ class MotionModel:
     @property
     def Q(self):
         """Return a Q matrix from the G matrix."""
-        return self.G.transpose() * self.G
+        # return self.G.transpose() * self.G
+        return self.G.T @ self.G
 
     def reshape(self):
         """Reshapes matrices to the correct dimensions. Only need to call this
@@ -113,7 +114,13 @@ class MotionModel:
         # if we defined a model, restructure matrices to the correct shapes
         # do some parsing to check that the model is specified correctly
         if s and m:
-            shapes = {"A": (s, s), "H": (m, s), "P": (s, s), "R": (m, m)}
+            shapes = {
+                "A": (s, s),
+                "H": (m, s),
+                "P": (s, s),
+                "R": (m, m),
+                "G": (1, s),
+            }
             for m_name in shapes:
                 try:
                     m_array = getattr(self, m_name)

--- a/btrack/utils.py
+++ b/btrack/utils.py
@@ -181,9 +181,7 @@ def read_motion_model(config: dict) -> MotionModel:
                 sigma = motion_config[field]["sigma"]
             else:
                 sigma = 1.0
-            matrix = np.matrix(
-                motion_config[field]["matrix"], dtype=np.float64
-            )
+            matrix = np.array(motion_config[field]["matrix"], dtype=np.float64)
             model_kwargs[field] = matrix * sigma
         else:
             model_kwargs[field] = motion_config[field]
@@ -252,7 +250,7 @@ def read_object_model(config: dict) -> ObjectModel:
     model.states = object_config["states"]
 
     for matrix in matrices:
-        m_data = np.matrix(object_config[matrix]["matrix"], dtype="float")
+        m_data = np.array(object_config[matrix]["matrix"], dtype="float")
         setattr(model, matrix, m_data)
 
     # call the reshape function to set the matrices to the correct shapes


### PR DESCRIPTION
This PR implements the suggestion to [not use numpy `matrix` class](https://numpy.org/doc/stable/reference/arrays.classes.html#matrix-objects) when building the model configuration.

Resolves #54 