### PR TITLE
Add API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ bworker.py
 *.o
 *.pyc
 .vscode
+
+docs/api/*
+
 .tox
 .coverage
 coverage.xml

--- a/btrack/btypes.py
+++ b/btrack/btypes.py
@@ -25,7 +25,7 @@ import numpy as np
 
 from . import constants, utils
 
-__all__ = ['PyTrackObject', 'PyTrackingInfo', 'Tracklet']
+__all__ = ["PyTrackObject", "PyTrackingInfo", "Tracklet"]
 
 
 class PyTrackObject(ctypes.Structure):

--- a/btrack/btypes.py
+++ b/btrack/btypes.py
@@ -25,12 +25,11 @@ import numpy as np
 
 from . import constants, utils
 
+__all__ = ['PyTrackObject', 'PyTrackingInfo', 'Tracklet']
+
 
 class PyTrackObject(ctypes.Structure):
     """The base `btrack` track object.
-
-    Attributes
-    ----------
 
     Notes
     -----

--- a/btrack/dataio.py
+++ b/btrack/dataio.py
@@ -39,7 +39,7 @@ logger = logging.getLogger("worker_process")
 
 
 # Choose a subset of classes/functions to document in public facing API
-__all__ = ['import_CSV']
+__all__ = ["import_CSV"]
 
 
 class _PyTrackObjectFactory:

--- a/btrack/dataio.py
+++ b/btrack/dataio.py
@@ -38,6 +38,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger("worker_process")
 
 
+# Choose a subset of classes/functions to document in public facing API
+__all__ = ['import_CSV']
+
+
 class _PyTrackObjectFactory:
     def __init__(self):
         raise DeprecationWarning("_PyTrackObjectFactory has been deprecated.")
@@ -134,16 +138,16 @@ def import_JSON(filename: str):
 
 
 def import_CSV(filename: str):
-    """Import localizations from a CSV file
+    """Import localizations from a CSV file.
 
     Notes
     -----
     CSV file should have one of the following formats:
 
-    t, x, y
-    t, x, y, label
-    t, x, y, z
-    t, x, y, z, label
+    - t, x, y
+    - t, x, y, label
+    - t, x, y, z
+    - t, x, y, z, label
     """
 
     objects = []

--- a/btrack/models.py
+++ b/btrack/models.py
@@ -27,6 +27,8 @@ import numpy as np
 from . import constants, utils
 from .optimise.hypothesis import H_TYPES, PyHypothesisParams
 
+__all__ = ['MotionModel', 'ObjectModel']
+
 
 @dataclasses.dataclass
 class MotionModel:

--- a/btrack/models.py
+++ b/btrack/models.py
@@ -27,7 +27,7 @@ import numpy as np
 from . import constants, utils
 from .optimise.hypothesis import H_TYPES, PyHypothesisParams
 
-__all__ = ['MotionModel', 'ObjectModel']
+__all__ = ['MotionModel', 'ObjectModel', 'HypothesisModel']
 
 
 @dataclasses.dataclass

--- a/btrack/models.py
+++ b/btrack/models.py
@@ -27,7 +27,7 @@ import numpy as np
 from . import constants, utils
 from .optimise.hypothesis import H_TYPES, PyHypothesisParams
 
-__all__ = ['MotionModel', 'ObjectModel', 'HypothesisModel']
+__all__ = ["MotionModel", "ObjectModel", "HypothesisModel"]
 
 
 @dataclasses.dataclass

--- a/btrack/utils.py
+++ b/btrack/utils.py
@@ -355,7 +355,6 @@ def tracks_to_napari(tracks: list, ndim: int = 3, replace_nan: bool = True):
         Replace instances of NaN/inf in the track properties with an
         interpolated value.
 
-
     Returns
     -------
     data : array (N, D+1)

--- a/btrack/utils.py
+++ b/btrack/utils.py
@@ -30,12 +30,11 @@ from . import btypes, constants
 from ._localization import segmentation_to_objects
 from .models import HypothesisModel, MotionModel, ObjectModel
 
+# Choose a subset of classes/functions to document in public facing API
+__all__ = ['segmentation_to_objects']
+
 # get the logger instance
 logger = logging.getLogger(__name__)
-
-
-# add an alias here
-segmentation_to_objects = segmentation_to_objects
 
 
 def load_config(filename: os.PathLike) -> dict:

--- a/btrack/utils.py
+++ b/btrack/utils.py
@@ -31,7 +31,7 @@ from ._localization import segmentation_to_objects
 from .models import HypothesisModel, MotionModel, ObjectModel
 
 # Choose a subset of classes/functions to document in public facing API
-__all__ = ['segmentation_to_objects']
+__all__ = ["segmentation_to_objects"]
 
 # get the logger instance
 logger = logging.getLogger(__name__)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,9 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+
+# Error on warnings, but don't stop for individual warnings
+SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = build

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,3 +6,8 @@ API Reference
 .. automodapi:: btrack.btypes
 
 .. automodapi:: btrack.models
+
+.. automodapi:: btrack.dataio
+
+.. automodapi:: btrack.utils
+   :allowed-package-names: btrack._localization

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,8 @@
+API Reference
+=============
+
+.. automodapi:: btrack
+
+.. automodapi:: btrack.btypes
+
+.. automodapi:: btrack.models

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,8 +34,8 @@ release = "v" + btrack.__version__
 # ones.
 extensions = [
     "sphinx_panels",
-    'sphinx_automodapi.automodapi',
-    'numpydoc',
+    "sphinx_automodapi.automodapi",
+    "numpydoc",
 ]
 
 numpydoc_show_class_members = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,12 @@ release = "v" + btrack.__version__
 # ones.
 extensions = [
     "sphinx_panels",
+    'sphinx_automodapi.automodapi',
+    'numpydoc',
 ]
+
+numpydoc_show_class_members = False
+automodapi_inheritance_diagram = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ The global solution identifies a sequence of high-likelihood hypotheses that acc
 
       user_guide/installation
       user_guide/index
+      api
 
     ---
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,4 @@
+numpydoc
 sphinx
+sphinx-automodapi
 sphinx-panels

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 cvxopt>=1.2.0
 h5py>=2.10.0
-matplotlib>=3.1.1
 numpy>=1.17.3
 pooch>=1.0.0
 scikit-image>=0.16.2


### PR DESCRIPTION
Fixes https://github.com/quantumjot/BayesianTracker/issues/102. @quantumjot I've only added `btrack`, `btrack.types` and `btrack.models` to the docs as they seem like the main user facing API? Is there anything else that should be added or removed?