### PR TITLE
Refactor tracker config using pydantic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,13 @@
 Updates
 =======
+0.4.4
+-----
+- Allow Q matrix to be directly defined in config file
+- Use pydantic for tracker configuration
+- Allow config export
+- Add imaging volume dimensionality inference
+- Fix warnings for implicit type conversion
+
 0.4.3
 -----
 - Bug fix to remove indexing error for objects in the last frame

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Updates
 - Allow config export
 - Add imaging volume dimensionality inference
 - Fix warnings for implicit type conversion
+- Removed _PyTrackObjectFactory
 
 0.4.3
 -----

--- a/btrack/btypes.py
+++ b/btrack/btypes.py
@@ -19,7 +19,7 @@ __email__ = "a.lowe@ucl.ac.uk"
 
 import ctypes
 from collections import OrderedDict
-from typing import Dict, NamedTuple, Tuple, Union
+from typing import Dict, NamedTuple, Optional, Tuple, Union
 
 import numpy as np
 
@@ -29,7 +29,12 @@ from . import constants, utils
 class ImagingVolume(NamedTuple):
     x: Tuple[float, float]
     y: Tuple[float, float]
-    z: Tuple[float, float]
+    z: Optional[Tuple[float, float]] = None
+
+    @property
+    def ndim(self) -> int:
+        """Infer the dimensionality from the volume."""
+        return 2 if self.z is None else 3
 
 
 class PyTrackObject(ctypes.Structure):

--- a/btrack/btypes.py
+++ b/btrack/btypes.py
@@ -19,7 +19,7 @@ __email__ = "a.lowe@ucl.ac.uk"
 
 import ctypes
 from collections import OrderedDict
-from typing import Dict, NamedTuple, Optional, Tuple, Union
+from typing import Any, Dict, NamedTuple, Optional, Tuple
 
 import numpy as np
 
@@ -100,13 +100,13 @@ class PyTrackObject(ctypes.Structure):
         self._properties = {}
 
     @property
-    def properties(self) -> Dict[str, Union[bool, int, float]]:
+    def properties(self) -> Dict[str, Any]:
         if self.dummy:
             return {}
         return self._properties
 
     @properties.setter
-    def properties(self, properties: Dict[str, Union[bool, int, float]]):
+    def properties(self, properties: Dict[str, Any]):
         """Set the object properties."""
         self._properties.update(properties)
 
@@ -124,16 +124,14 @@ class PyTrackObject(ctypes.Structure):
     def state(self) -> constants.States:
         return constants.States(self.label)
 
-    def to_dict(self) -> Dict[str, Union[bool, int, float]]:
+    def to_dict(self) -> Dict[str, Any]:
         """Return a dictionary of the fields and their values."""
         stats = {k: getattr(self, k) for k, _ in PyTrackObject._fields_}
         stats.update(self.properties)
         return stats
 
     @staticmethod
-    def from_dict(
-        properties: Dict[str, Union[bool, int, float]]
-    ) -> "PyTrackObject":
+    def from_dict(properties: Dict[str, Any]) -> "PyTrackObject":
         """Build an object from a dictionary."""
         obj = PyTrackObject()
         fields = {k: kt for k, kt in PyTrackObject._fields_}
@@ -212,7 +210,7 @@ class PyTrackingInfo(ctypes.Structure):
         ("complete", ctypes.c_bool),
     ]
 
-    def to_dict(self) -> Dict[str, Union[bool, int, float]]:
+    def to_dict(self) -> Dict[str, Any]:
         """Return a dictionary of the statistics"""
         # TODO(arl): make this more readable by converting seconds, ms
         # and interpreting error messages?

--- a/btrack/btypes.py
+++ b/btrack/btypes.py
@@ -13,9 +13,7 @@
 # Created:  14/08/2014
 # -------------------------------------------------------------------------------
 
-
-__author__ = "Alan R. Lowe"
-__email__ = "a.lowe@ucl.ac.uk"
+from __future__ import annotations
 
 import ctypes
 from collections import OrderedDict
@@ -131,7 +129,7 @@ class PyTrackObject(ctypes.Structure):
         return stats
 
     @staticmethod
-    def from_dict(properties: Dict[str, Any]) -> "PyTrackObject":
+    def from_dict(properties: Dict[str, Any]) -> PyTrackObject:
         """Build an object from a dictionary."""
         obj = PyTrackObject()
         fields = {k: kt for k, kt in PyTrackObject._fields_}

--- a/btrack/btypes.py
+++ b/btrack/btypes.py
@@ -107,17 +107,23 @@ class PyTrackObject(ctypes.Structure):
     def from_dict(properties: dict):
         """Build an object from a dictionary."""
         obj = PyTrackObject()
-        fields = [k for k, _ in PyTrackObject._fields_]
-        attr = [k for k in fields if k in properties.keys()]
+        fields = {k: kt for k, kt in PyTrackObject._fields_}
+        attr = [k for k in fields.keys() if k in properties.keys()]
         for key in attr:
-            try:
-                setattr(obj, key, properties[key])
-            except TypeError:
-                setattr(obj, key, int(properties[key]))
+
+            new_data = properties[key]
+
+            # fix for implicit type conversion
+            if key in ("ID", "t", "states", "label"):
+                setattr(obj, key, int(new_data))
+            elif key in ("dummy",):
+                setattr(obj, key, bool(new_data))
+            else:
+                setattr(obj, key, float(new_data))
 
         # we can add any extra details to the properties dictionary
         obj.properties = {
-            k: v for k, v in properties.items() if k not in fields
+            k: v for k, v in properties.items() if k not in fields.keys()
         }
         return obj
 

--- a/btrack/btypes.py
+++ b/btrack/btypes.py
@@ -19,11 +19,17 @@ __email__ = "a.lowe@ucl.ac.uk"
 
 import ctypes
 from collections import OrderedDict
-from typing import Dict, Union
+from typing import Dict, NamedTuple, Tuple, Union
 
 import numpy as np
 
 from . import constants, utils
+
+
+class ImagingVolume(NamedTuple):
+    x: Tuple[float, float]
+    y: Tuple[float, float]
+    z: Tuple[float, float]
 
 
 class PyTrackObject(ctypes.Structure):

--- a/btrack/btypes.py
+++ b/btrack/btypes.py
@@ -42,6 +42,26 @@ class PyTrackObject(ctypes.Structure):
 
     Attributes
     ----------
+    ID : int
+        The unique ID of the object.
+    x : float
+        The x coordinate.
+    y : float
+        The y coordinate.
+    z : float
+        The z coordinate.
+    t : int
+        The timestamp.
+    dummy: bool
+        Flag for whether the objects is real or a dummy (inserted by the
+        tracker when no observation can be linked).
+    states : int
+        The number of states of the object. This corresponds to the number of
+        possible labels.
+    label : int
+        The label of the object.
+    prob : float
+        The probability of the label.
 
     Notes
     -----
@@ -139,19 +159,33 @@ class PyTrackingInfo(ctypes.Structure):
 
     Primitive class to store information about the tracking output.
 
-    Params:
-        error: error code from the tracker
-        n_tracks: total number of tracks initialised during tracking
-        n_active: number of active tracks
-        n_conflicts: number of conflicts
-        n_lost: number of lost tracks
-        t_update_belief: time to update belief matrix in ms
-        t_update_link: time to update links in ms
-        t_total_time: total time to track objects
-        p_link: typical probability of association
-        p_lost: typical probability of losing track
+    Attributes
+    ----------
+    error :
+        Error code from the tracker.
+    n_tracks : int
+        Total number of tracks initialised during tracking.
+    n_active : int
+        Number of active tracks.
+    n_conflicts : int
+        Number of conflicts.
+    n_lost : int
+        Number of lost tracks.
+    t_update_belief : float
+        Time to update belief matrix in ms.
+    t_update_link : float
+        Time to update links in ms.
+    t_total_time : float
+        Total time to track objects.
+    p_link : float
+        Typical probability of association.
+    p_lost : float
+        Typical probability of losing track.
+    complete : bool
+        Flag denoting that the tracking is complete.
 
-    Notes:
+    Notes
+    -----
         TODO(arl): should update to give more useful statistics, perhaps
         histogram of probabilities and timings.
 

--- a/btrack/config.py
+++ b/btrack/config.py
@@ -22,6 +22,7 @@ class TrackerConfig(BaseModel):
     Parameters
     ----------
     name : str
+    version : str
     verbose : bool
     motion_model : Optional[MotionModel]
     object_model : Optional[ObjectModel]
@@ -34,6 +35,7 @@ class TrackerConfig(BaseModel):
     """
 
     name: str = "Default"
+    version: str = constants.get_version()
     verbose: bool = False
     motion_model: Optional[MotionModel] = None
     object_model: Optional[ObjectModel] = None

--- a/btrack/config.py
+++ b/btrack/config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Optional
 
 import numpy as np
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 from . import constants
 from .btypes import ImagingVolume
@@ -74,8 +74,15 @@ class TrackerConfig(BaseModel):
     update_method: constants.BayesianUpdates = constants.BayesianUpdates.EXACT
     optimizer_options: dict = constants.GLPK_OPTIONS
 
+    @validator("volume", pre=True, always=True)
+    def parse_volume(cls, v):
+        if isinstance(v, tuple):
+            return ImagingVolume(*v)
+        return v
+
     class Config:
         arbitrary_types_allowed = True
+        validate_assignment = True
         json_encoders = {
             np.ndarray: lambda x: x.ravel().tolist(),
         }

--- a/btrack/config.py
+++ b/btrack/config.py
@@ -22,16 +22,44 @@ class TrackerConfig(BaseModel):
     Parameters
     ----------
     name : str
+        A name identifier for the model.
     version : str
+        A string representing the version of `btrack` used.
     verbose : bool
+        A flag to set the verbosity level while logging the output.
     motion_model : Optional[MotionModel]
+        The `btrack` motion model. See `models.MotionModel` for more details.
     object_model : Optional[ObjectModel]
+        The `btrack` object model. See `models.ObjectModel` for more details.
     hypothesis_model : Optional[HypothesisModel]
+        The `btrack` hypothesis model. See `models.HypothesisModel` for more
+        details.
     max_search_radius : float
+        The maximum search radius of the algorithm in isotropic units of the
+        data. Should be greater than zero.
     return_kalman : bool
+        Flag to request the Kalman debug info when returning tracks.
     volume : Optional[ImagingVolume]
+        The imaging volume as [(xlo, xhi), ..., (zlo, zhi)]. See
+        `btypes.ImagingVolume` for more details.
     update_method : constants.BayesianUpdates
+        The method to perform the bayesian updates during tracklet linking.
+            BayesianUpdates.EXACT
+                Use the exact Bayesian update method. Can be slow for systems
+                with many objects.
+            BayesianUpdates.APPROXIMATE
+                Use the approximate Bayesian update method. Useful for systems
+                with may objects.
+            BayesianUpdates.CUDA
+                Use the CUDA implementation of the Bayesian update method. Not
+                currently implemented.
     optimizer_options: dict
+        Additional options to pass to the optimizer. See `cvxopt.glpk` for more
+        details of options that can be passed.
+
+    Notes
+    -----
+    TODO(arl): add more validation to parameters.
     """
 
     name: str = "Default"

--- a/btrack/config.py
+++ b/btrack/config.py
@@ -107,9 +107,9 @@ def load_config(filename: os.PathLike) -> TrackerConfig:
     with open(filename, "r") as json_file:
         json_data = json.load(json_file)
 
-    try:
+    if "TrackerConfig" in json_data:
         cfg = _load_legacy_config(json_data)
-    except KeyError:
+    else:
         cfg = _load_config(json_data)
 
     assert cfg.motion_model is not None

--- a/btrack/config.py
+++ b/btrack/config.py
@@ -1,0 +1,84 @@
+import json
+import logging
+import os
+from typing import NamedTuple, Optional, Tuple
+
+from pydantic import BaseModel, validator
+
+from . import constants
+from .models import HypothesisModel, MotionModel, ObjectModel
+from .utils import read_hypothesis_model, read_motion_model, read_object_model
+
+# get the logger instance
+logger = logging.getLogger(__name__)
+
+
+class ImagingVolume(NamedTuple):
+    x: Tuple[float, float]
+    y: Tuple[float, float]
+    z: Tuple[float, float]
+
+
+class TrackerConfig(BaseModel):
+    """Configuration for `BayesianTracker`.
+
+    Parameters
+    ----------
+    name : str
+    verbose : bool
+    motion_model : Optional[MotionModel]
+    object_model : Optional[ObjectModel]
+    hypothesis_model : Optional[HypothesisModel]
+    max_search_radius : float = constants.MAX_SEARCH_RADIUS
+    return_kalman : bool = False
+    frame_range : Tuple[int] = (0, 0)
+    volume : Tuple[Tuple[float, float], Tuple[float], Tuple[float]] = ((0, 0), (0, 0), (0, 0))
+    update_method : constants.BayesianUpdates
+    optimizer_options: dict
+
+    """
+
+    name: str = "Default"
+    verbose: bool = False
+    motion_model: Optional[MotionModel] = None
+    object_model: Optional[ObjectModel] = None
+    hypothesis_model: Optional[HypothesisModel] = None
+    max_search_radius: float = constants.MAX_SEARCH_RADIUS
+    return_kalman: bool = False
+    frame_range: Tuple[int] = (0, 0)
+    volume: Optional[ImagingVolume] = None
+    update_method: constants.BayesianUpdates = constants.BayesianUpdates.EXACT
+    optimizer_options: dict = constants.GLPK_OPTIONS
+
+    @validator("name")
+    def testit(cls, n):
+        if n != "Alan":
+            raise Exception
+        return n
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+PATH = "/Users/arl/Dropbox/Code/py3/BayesianTracker/models/cell_config.json"
+
+
+def load_config(filename: os.PathLike) -> TrackerConfig:
+    pass
+
+
+def _load_config_legacy(filename: os.PathLike = PATH) -> TrackerConfig:
+    """Load a legacy config file."""
+    with open(filename, "r") as config_file:
+        config = json.load(config_file)
+
+    config = config["TrackerConfig"]
+
+    logger.info(f"Loading configuration file: {filename}")
+    t_config = {
+        "motion_model": read_motion_model(config),
+        "object_model": read_object_model(config),
+        "hypothesis_model": read_hypothesis_model(config),
+    }
+
+    return TrackerConfig(**t_config)

--- a/btrack/constants.py
+++ b/btrack/constants.py
@@ -21,7 +21,7 @@ PROB_NOT_ASSIGN = 0.1
 DEBUG = True
 EXPORT_FORMATS = frozenset([".json", ".mat", ".hdf5"])
 VOLUME = ((0, 1024), (0, 1024), (-1e5, 1e5))
-GLPK_OPTIONS = {"tm_lim": int(6e4)}
+GLPK_OPTIONS = {"tm_lim": 60_000}
 
 
 DEFAULT_OBJECT_KEYS = ["t", "x", "y", "z", "label"]

--- a/btrack/constants.py
+++ b/btrack/constants.py
@@ -21,9 +21,7 @@ PROB_NOT_ASSIGN = 0.1
 DEBUG = True
 EXPORT_FORMATS = frozenset([".json", ".mat", ".hdf5"])
 VOLUME = ((0, 1024), (0, 1024), (-1e5, 1e5))
-HDF_CHUNK_CACHE = 100 * 1024 * 1024
-USER_MODEL_DIR = ""
-GLPK_OPTIONS = {}
+GLPK_OPTIONS = {"tm_lim": int(6e4)}
 
 
 DEFAULT_OBJECT_KEYS = ["t", "x", "y", "z", "label"]

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -235,7 +235,7 @@ class BayesianTracker:
         if not attr.startswith("_") and self.configuration.verbose:
             logger.info(f"Setting {attr} -> {value}")
 
-        if hasattr(config.TrackerConfig, attr):
+        if attr in config.TrackerConfig.__fields__:
             setattr(self.configuration, attr, value)
         else:
             object.__setattr__(self, attr, value)
@@ -349,17 +349,17 @@ class BayesianTracker:
 
         Parameters
         ----------
-        volume : tuple
+        volume : tuple, ImagingVolume
             A tuple describing the imaging volume.
         """
         volume = btypes.ImagingVolume(*volume)
 
         # if we've only provided 2 dims, set the last one to a default
         if volume.ndim == 2:
-            volume = volume + ((-1e5, 1e5),)
+            z = (-1e5, 1e5)
+            volume = btypes.ImagingVolume(volume.x, volume.y, z)
 
         self._lib.set_volume(self._engine, np.array(volume, dtype=float))
-        # logger.info(f"Set volume to {volume}")
 
     def _motion_model(self, model: models.MotionModel) -> None:
         """Set a new motion model. Must be of type MotionModel, either loaded

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -186,13 +186,7 @@ class BayesianTracker:
 
         # default parameters and space for stored objects
         self._objects = []
-        # self._motion_model = None
-        # self._object_model = None
         self._frame_range = [0, 0]
-        # self.max_search_radius = constants.MAX_SEARCH_RADIUS
-        # self.return_kalman = False
-        # self.verbose = verbose
-        # self.optimizer_options = constants.GLPK_OPTIONS
 
     def __enter__(self):
         logger.info("Starting BayesianTracker session")

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -256,14 +256,10 @@ class BayesianTracker:
 
     def _max_search_radius(self, max_search_radius: int):
         """Set the maximum search radius for fast cost updates."""
-        # logger.info(f"Setting max XYZ search radius to: {max_search_radius}")
-        # self.configuration.max_search_radius = max_search_radius
         self._lib.max_search_radius(self._engine, max_search_radius)
 
     def _update_method(self, method: Union[str, constants.BayesianUpdates]):
         """Set the method for updates, EXACT, APPROXIMATE, CUDA etc..."""
-        # logger.info(f"Setting Bayesian update method to: {method}")
-        # self.configuration.update_method = method
         self._lib.set_update_mode(self._engine, method.value)
 
     @property
@@ -461,7 +457,6 @@ class BayesianTracker:
             return
 
         logger.info("Starting tracking... ")
-        # ret, tm = timeit( lib.track,  self._engine )
         ret = self._lib.track(self._engine)
 
         # get the statistics

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -231,10 +231,7 @@ class BayesianTracker:
         elif isinstance(configuration, (str, os.PathLike)):
             configuration = config.load_config(configuration)
 
-        # for key in configuration.__fields__.keys():
-        #     value = getattr(configuration, key)
-        #     if value:
-        #         setattr(self, key, value)
+        # TODO(arl): need to run the setters for other options here
         self.motion_model = configuration.motion_model
         # # self.object_model = configuration.object_model
         self._config = configuration

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -314,12 +314,18 @@ class BayesianTracker:
 
         Notes
         -----
-        L - a unique label of the track (label of markers, 16-bit positive)
-        B - a zero-based temporal index of the frame in which the track begins
-        E - a zero-based temporal index of the frame in which the track ends
-        P - label of the parent track (0 is used when no parent is defined)
-        R - label of the root track
-        G - generational depth (from root)
+        L : int
+            A unique label of the track (label of markers, 16-bit positive).
+        B : int
+            A zero-based temporal index of the frame in which the track begins.
+        E : int
+            A zero-based temporal index of the frame in which the track ends.
+        P : int
+            Label of the parent track (0 is used when no parent is defined).
+        R : int
+            Label of the root track.
+        G : int
+            Generational depth (from root).
         """
 
         def _lbep_table(t):
@@ -369,6 +375,7 @@ class BayesianTracker:
 
     @property
     def motion_model(self) -> models.MotionModel:
+        """Return the current motion model."""
         return self.configuration.motion_model
 
     @motion_model.setter
@@ -402,6 +409,7 @@ class BayesianTracker:
 
     @property
     def object_model(self) -> models.ObjectModel:
+        """Return the current object model."""
         return self.configuration.object_model
 
     @object_model.setter
@@ -427,19 +435,23 @@ class BayesianTracker:
 
     @property
     def hypothesis_model(self) -> models.HypothesisModel:
+        """Return the current hypothesis model."""
         return self.configuration.hypothesis_model
 
     @hypothesis_model.setter
     def hypotheses_model(self, model: models.HypothesisModel) -> None:
+        """Set the current hypotheis model."""
         logger.info(f"Loading hypothesis model: {model.name}")
         self.configuration.hypotheses_model = model
 
     @property
     def frame_range(self) -> Tuple[int, int]:
+        """Return the frame range."""
         return tuple(self.configuration.frame_range)
 
     @property
     def objects(self) -> List[btypes.PyTrackObject]:
+        """Return the list of objects added through the append method."""
         return self._objects
 
     def append(
@@ -470,7 +482,7 @@ class BayesianTracker:
         self._objects += objects
 
     def _stats(self, info_ptr: ctypes.POINTER) -> btypes.PyTrackingInfo:
-        """Cast the info pointer back to an object"""
+        """Cast the info pointer back to an object."""
 
         if not isinstance(info_ptr, ctypes.POINTER(btypes.PyTrackingInfo)):
             raise TypeError("Stats requires the pointer to the object")
@@ -478,7 +490,7 @@ class BayesianTracker:
         return info_ptr.contents
 
     def track(self) -> None:
-        """Run the actual tracking algorithm"""
+        """Run the actual tracking algorithm."""
 
         if not self._initialised:
             logger.error("Tracker has not been configured")

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -191,7 +191,7 @@ class BayesianTracker:
 
         Parameters
         ----------
-        configuration : dict, os.PathLike, config.TrackerConfig
+        configuration :
             A dictionary containing the configuration options for a tracking
             session.
         """

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -52,9 +52,9 @@ if not logger.handlers:
 class BayesianTracker:
     """BayesianTracker.
 
-    BayesianTracker is a multi object tracking algorithm, specifically
-    used to reconstruct tracks in crowded fields. Here we use a probabilistic
-    network of information to perform the trajectory linking.
+    BayesianTracker is a multi object tracking algorithm, specifically used to
+    reconstruct tracks in crowded fields. Here we use a probabilistic network of
+    information to perform the trajectory linking.
 
     Parameters
     ----------
@@ -98,8 +98,10 @@ class BayesianTracker:
                 currently implemented.
     return_kalman : bool
         Flag to request the Kalman debug info when returning tracks.
-    lbep :
+    lbep : List[List]
         Return an LBEP table of the track lineages.
+    configuration : config.TrackerConfig
+        Return the current configuration.
 
     Notes
     -----
@@ -108,19 +110,18 @@ class BayesianTracker:
 
     The tracking algorithm assembles reliable sections of track that do not
     contain splitting events (tracklets). Each new tracklet initiates a
-    probabilistic model in the form of a Kalman filter (Kalman, 1960), and
+    probabilistic model in the form of a Kalman filter [1]_, and
     utilises this to predict future states (and error in states) of each of the
     objects in the field of view.  We assign new observations to the growing
     tracklets (linking) by evaluating the posterior probability of each
     potential linkage from a Bayesian belief matrix for all possible linkages
-    (Narayana and Haverkamp, 2007). The best linkages are those with the
-    highest posterior probability.
+    [2]_. The best linkages are those with the highest posterior probability.
 
     This class is a wrapper for the C++ implementation of the BayesianTracker.
 
     Data can be passed in in the following formats:
         - btrack PyTrackObject (defined in btypes)
-        - Optional JSON files using loaders
+        - CSV
         - HDF
 
     Can be used with ContextManager support, like this:
@@ -135,25 +136,33 @@ class BayesianTracker:
     protocol, or other metadata is needed for further analysis. The references
     can be used to make symbolic links in HDF5 files, for example.
 
-    Use the .tracks to return Tracklets, or .refs to return the references.
+    Use optimise to generate hypotheses for global optimisation [3, 4]_. Read
+    the `optimiser.TrackOptimiser` documentation for more information about the
+    track linker.
 
-    Use optimise to generate hypotheses for global optimisation. Read the
-    TrackLinker documentation for more information about the track linker.
+    Full details of the implementation can be found in [5, 6]_.
 
     References
     ----------
-    'A Bayesian algorithm for tracking multiple moving objects in outdoor
+    .. [1] 'A new approach to linear filtering and prediction problems.'
+    Kalman RE, 1960 Journal of Basic Engineering
+
+    .. [2] 'A Bayesian algorithm for tracking multiple moving objects in outdoor
     surveillance video', Narayana M and Haverkamp D 2007 IEEE
 
-    'Report Automated Cell Lineage Construction' Al-Kofahi et al.
+    .. [3] 'Report Automated Cell Lineage Construction' Al-Kofahi et al.
     Cell Cycle 2006 vol. 5 (3) pp. 327-335
 
-    'Reliable cell tracking by global data association', Bise et al.
+    .. [4] 'Reliable cell tracking by global data association', Bise et al.
     2011 IEEE Symposium on Biomedical Imaging pp. 1004-1010
 
-    'Local cellular neighbourhood controls proliferation in cell
+    .. [5] 'Local cellular neighbourhood controls proliferation in cell
     competition', Bove A, Gradeci D, Fujita Y, Banerjee S, Charras G and
     Lowe AR 2017 Mol. Biol. Cell vol 28 pp. 3215-3228
+
+    .. [6] 'Automated deep lineage tree analysis using a Bayesian single cell
+    tracking approach', Ulicna K, Vallardi G, Charras G and Lowe AR 2021 Front.
+    Comput. Sci. 3
     """
 
     def __init__(

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -584,8 +584,7 @@ class BayesianTracker:
 
         # if we have not been provided with optimizer options, use the default
         # from the configuration.
-        if not options:
-            options = self.configuration.optimizer_options
+        options = self.configuration.optimizer_options if not options else options
 
         # if we don't have any hypotheses return
         if not hypotheses:
@@ -715,8 +714,7 @@ class BayesianTracker:
         """Return the data in a format for a napari tracks layer.
         See `utils.tracks_to_napari`."""
 
-        if ndim is None:
-            ndim = self.configuration.volume.ndim
+        ndim = self.configuration.volume.ndim if ndim is None else ndim
 
         return utils.tracks_to_napari(
             self.tracks, ndim, replace_nan=replace_nan

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -74,7 +74,8 @@ class BayesianTracker:
     dummies : list
         The dummy objects inserted by the tracker.
     volume : tuple
-        The imaging volume as [(xlo, xhi), ..., (zlo, zhi), (tlo, thi)]
+        The imaging volume as [(xlo, xhi), ..., (zlo, zhi)]. See
+        `btypes.ImagingVolume` for more details.
     frame_range : tuple
         The frame range for tracking, essentially the last dimension of volume.
     max_search_radius : int, float

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -136,11 +136,11 @@ class BayesianTracker:
     protocol, or other metadata is needed for further analysis. The references
     can be used to make symbolic links in HDF5 files, for example.
 
-    Use optimise to generate hypotheses for global optimisation [3, 4]_. Read
+    Use optimise to generate hypotheses for global optimisation [3][4]_. Read
     the `optimiser.TrackOptimiser` documentation for more information about the
     track linker.
 
-    Full details of the implementation can be found in [5, 6]_.
+    Full details of the implementation can be found in [5][6]_.
 
     References
     ----------

--- a/btrack/dataio.py
+++ b/btrack/dataio.py
@@ -38,11 +38,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger("worker_process")
 
 
-class _PyTrackObjectFactory:
-    def __init__(self):
-        raise DeprecationWarning("_PyTrackObjectFactory has been deprecated.")
-
-
 def localizations_to_objects(localizations):
     """Take a numpy array or pandas dataframe and convert to PyTrackObjects.
 

--- a/btrack/models.py
+++ b/btrack/models.py
@@ -289,7 +289,7 @@ class HypothesisModel(BaseModel):
 
     @validator("hypotheses", pre=True)
     def parse_hypotheses(cls, hypotheses):
-        if not all([h in H_TYPES for h in hypotheses]):
+        if not all(h in H_TYPES for h in hypotheses):
             raise ValueError
         return hypotheses
 

--- a/btrack/models.py
+++ b/btrack/models.py
@@ -30,6 +30,7 @@ from .optimise.hypothesis import H_TYPES, PyHypothesisParams
 def _check_symmetric(
     x: np.array, rtol: float = 1e-5, atol: float = 1e-8
 ) -> bool:
+    """Check that a matrix is symmetric by comparing with it's own transpose."""
     return np.allclose(x, x.T, rtol=rtol, atol=atol)
 
 

--- a/btrack/models.py
+++ b/btrack/models.py
@@ -160,6 +160,7 @@ class MotionModel(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
+        validate_assignment = True
 
 
 class ObjectModel(BaseModel):
@@ -205,6 +206,7 @@ class ObjectModel(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
+        validate_assignment = True
 
 
 class HypothesisModel(BaseModel):
@@ -308,3 +310,6 @@ class HypothesisModel(BaseModel):
         # set the hypotheses to generate
         h_params.hypotheses_to_generate = self.hypotheses_to_generate()
         return h_params
+
+    class Config:
+        validate_assignment = True

--- a/btrack/models.py
+++ b/btrack/models.py
@@ -115,17 +115,17 @@ class MotionModel(BaseModel):
     @validator("A")
     def reshape_A(cls, a, values):
         shape = (values["states"], values["states"])
-        return np.reshape(a, shape, order="C")
+        return np.reshape(a, shape)
 
     @validator("H")
     def reshape_H(cls, h, values):
         shape = (values["measurements"], values["states"])
-        return np.reshape(h, shape, order="C")
+        return np.reshape(h, shape)
 
     @validator("P")
     def reshape_P(cls, p, values):
         shape = (values["states"], values["states"])
-        p = np.reshape(p, shape, order="C")
+        p = np.reshape(p, shape)
         if not _check_symmetric(p):
             raise ValueError("Matrix `P` is not symmetric.")
         return p
@@ -133,7 +133,7 @@ class MotionModel(BaseModel):
     @validator("R")
     def reshape_R(cls, r, values):
         shape = (values["measurements"], values["measurements"])
-        r = np.reshape(r, shape, order="C")
+        r = np.reshape(r, shape)
         if not _check_symmetric(r):
             raise ValueError("Matrix `R` is not symmetric.")
         return r
@@ -141,12 +141,12 @@ class MotionModel(BaseModel):
     @validator("G")
     def reshape_G(cls, g, values):
         shape = (1, values["states"])
-        return np.reshape(g, shape, order="C")
+        return np.reshape(g, shape)
 
     @validator("Q")
     def reshape_Q(cls, q, values):
         shape = (values["states"], values["states"])
-        q = np.reshape(q, shape, order="C")
+        q = np.reshape(q, shape)
         if not _check_symmetric(q):
             raise ValueError("Matrix `Q` is not symmetric.")
         return q
@@ -199,12 +199,12 @@ class ObjectModel(BaseModel):
     @validator("emission", "transition", "start", pre=True)
     def reshape_emission_transition(cls, v, values):
         shape = (values["states"], values["states"])
-        return np.reshape(v, shape, order="C")
+        return np.reshape(v, shape)
 
     @validator("emission", "transition", "start", pre=True)
     def reshape_start(cls, v, values):
         shape = (1, values["states"])
-        return np.reshape(v, shape, order="C")
+        return np.reshape(v, shape)
 
     class Config:
         arbitrary_types_allowed = True
@@ -290,7 +290,7 @@ class HypothesisModel(BaseModel):
     @validator("hypotheses", pre=True)
     def parse_hypotheses(cls, hypotheses):
         if not all(h in H_TYPES for h in hypotheses):
-            raise ValueError
+            raise ValueError("Unknown hypothesis type in `hypotheses`.")
         return hypotheses
 
     def hypotheses_to_generate(self) -> int:

--- a/btrack/utils.py
+++ b/btrack/utils.py
@@ -74,21 +74,21 @@ def log_stats(stats: dict) -> None:
 
 
 def read_motion_model(cfg: dict) -> MotionModel:
-    cfg = cfg.get("MotionModel", None)
+    cfg = cfg.get("MotionModel", {})
     if not cfg:
         return None
     return MotionModel(**cfg)
 
 
 def read_object_model(cfg: dict) -> ObjectModel:
-    cfg = cfg.get("ObjectModel", None)
+    cfg = cfg.get("ObjectModel", {})
     if not cfg:
         return None
     return ObjectModel(**cfg)
 
 
 def read_hypothesis_model(cfg: dict) -> HypothesisModel:
-    cfg = cfg.get("HypothesisModel", None)
+    cfg = cfg.get("HypothesisModel", {})
     if not cfg:
         return None
     return HypothesisModel(**cfg)

--- a/examples/example_tracking_pipeline.ipynb
+++ b/examples/example_tracking_pipeline.ipynb
@@ -33,7 +33,15 @@
    "execution_count": 1,
    "id": "7adac478",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "btrack.config\n"
+     ]
+    }
+   ],
    "source": [
     "import btrack\n",
     "\n",
@@ -129,7 +137,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x13b5acdc0>"
+       "<matplotlib.image.AxesImage at 0x12d849dc0>"
       ]
      },
      "execution_count": 6,
@@ -189,7 +197,52 @@
    "execution_count": 8,
    "id": "370348e3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>x</th>\n",
+       "      <th>y</th>\n",
+       "      <th>z</th>\n",
+       "      <th>t</th>\n",
+       "      <th>dummy</th>\n",
+       "      <th>states</th>\n",
+       "      <th>label</th>\n",
+       "      <th>prob</th>\n",
+       "      <th>area</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>517.573657</td>\n",
+       "      <td>9.07279</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>577</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "{'ID': 0, 'x': 517.5736568457539, 'y': 9.072790294627383, 'z': 0.0, 't': 0, 'dummy': False, 'states': 0, 'label': 5, 'prob': 0.0, 'area': 577}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "objects[0]"
    ]
@@ -285,36 +338,66 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO][2022/04/11 03:42:44 PM] btrack (v0.4.3) library imported\n",
-      "[INFO][2022/04/11 03:42:44 PM] Starting BayesianTracker session\n",
-      "[INFO][2022/04/11 03:42:44 PM] Loading motion model: cell_motion\n",
-      "[INFO][2022/04/11 03:42:44 PM] Setting max XYZ search radius to: 50\n",
-      "[INFO][2022/04/11 03:42:44 PM] Set volume to ((0, 1600), (0, 1200), (-100000.0, 100000.0))\n",
-      "[INFO][2022/04/11 03:42:44 PM] Starting tracking... \n",
-      "[INFO][2022/04/11 03:42:44 PM] Tracking objects in frames 0 to 99 (of 500)...\n",
-      "[INFO][2022/04/11 03:42:44 PM] Tracking objects in frames 100 to 199 (of 500)...\n",
-      "[INFO][2022/04/11 03:42:44 PM] Tracking objects in frames 200 to 299 (of 500)...\n",
-      "[INFO][2022/04/11 03:42:45 PM] Tracking objects in frames 300 to 399 (of 500)...\n",
-      "[INFO][2022/04/11 03:42:45 PM] Tracking objects in frames 400 to 499 (of 500)...\n",
-      "[INFO][2022/04/11 03:42:45 PM] SUCCESS.\n",
-      "[INFO][2022/04/11 03:42:45 PM]  - Found 507 tracks in 500 frames (in 0.0s)\n",
-      "[INFO][2022/04/11 03:42:45 PM]  - Inserted 97 dummy objects to fill tracking gaps\n",
-      "[INFO][2022/04/11 03:42:45 PM] Loading hypothesis model: cell_hypothesis\n",
-      "[INFO][2022/04/11 03:42:45 PM] Calculating hypotheses (relax: True)...\n",
-      "[INFO][2022/04/11 03:42:45 PM]  - Fates.FALSE_POSITIVE: 32 (of 507)\n",
-      "[INFO][2022/04/11 03:42:45 PM]  - Fates.LINK: 98 (of 348)\n",
-      "[INFO][2022/04/11 03:42:45 PM]  - Fates.DIVIDE: 110 (of 121)\n",
-      "[INFO][2022/04/11 03:42:45 PM]  - Fates.APOPTOSIS: 1 (of 2)\n",
-      "[INFO][2022/04/11 03:42:45 PM]  - Fates.INITIALIZE_BORDER: 53 (of 97)\n",
-      "[INFO][2022/04/11 03:42:45 PM]  - Fates.INITIALIZE_FRONT: 70 (of 72)\n",
-      "[INFO][2022/04/11 03:42:45 PM]  - Fates.INITIALIZE_LAZY: 34 (of 338)\n",
-      "[INFO][2022/04/11 03:42:45 PM]  - Fates.TERMINATE_BORDER: 53 (of 91)\n",
-      "[INFO][2022/04/11 03:42:45 PM]  - Fates.TERMINATE_BACK: 182 (of 185)\n",
-      "[INFO][2022/04/11 03:42:45 PM]  - Fates.TERMINATE_LAZY: 31 (of 231)\n",
-      "[INFO][2022/04/11 03:42:45 PM]  - TOTAL: 1992 hypotheses\n",
-      "[INFO][2022/04/11 03:42:45 PM] Completed optimization with 409 tracks\n",
+      "[INFO][2022/04/20 01:59:47 PM] btrack (v0.4.3) library imported\n",
+      "[INFO][2022/04/20 01:59:47 PM] Starting BayesianTracker session\n",
+      "[INFO][2022/04/20 01:59:47 PM] Setting name -> Default\n",
+      "[INFO][2022/04/20 01:59:47 PM] Setting version -> 0.4.3\n",
+      "[INFO][2022/04/20 01:59:47 PM] Setting verbose -> False\n",
+      "[INFO][2022/04/20 01:59:47 PM] Setting motion_model -> measurements=3 states=6 A=array([[1., 0., 0., 1., 0., 0.],\n",
+      "       [0., 1., 0., 0., 1., 0.],\n",
+      "       [0., 0., 1., 0., 0., 1.],\n",
+      "       [0., 0., 0., 1., 0., 0.],\n",
+      "       [0., 0., 0., 0., 1., 0.],\n",
+      "       [0., 0., 0., 0., 0., 1.]]) H=array([[1., 0., 0., 0., 0., 0.],\n",
+      "       [0., 1., 0., 0., 0., 0.],\n",
+      "       [0., 0., 1., 0., 0., 0.]]) P=array([[ 15.,   0.,   0.,   0.,   0.,   0.],\n",
+      "       [  0.,  15.,   0.,   0.,   0.,   0.],\n",
+      "       [  0.,   0.,  15.,   0.,   0.,   0.],\n",
+      "       [  0.,   0.,   0., 150.,   0.,   0.],\n",
+      "       [  0.,   0.,   0.,   0., 150.,   0.],\n",
+      "       [  0.,   0.,   0.,   0.,   0., 150.]]) R=array([[5., 0., 0.],\n",
+      "       [0., 5., 0.],\n",
+      "       [0., 0., 5.]]) G=array([[ 7.5,  7.5,  7.5, 15. , 15. , 15. ]]) Q=array([[ 56.25,  56.25,  56.25, 112.5 , 112.5 , 112.5 ],\n",
+      "       [ 56.25,  56.25,  56.25, 112.5 , 112.5 , 112.5 ],\n",
+      "       [ 56.25,  56.25,  56.25, 112.5 , 112.5 , 112.5 ],\n",
+      "       [112.5 , 112.5 , 112.5 , 225.  , 225.  , 225.  ],\n",
+      "       [112.5 , 112.5 , 112.5 , 225.  , 225.  , 225.  ],\n",
+      "       [112.5 , 112.5 , 112.5 , 225.  , 225.  , 225.  ]]) dt=1.0 accuracy=7.5 max_lost=5 prob_not_assign=0.001 name='cell_motion'\n",
+      "[INFO][2022/04/20 01:59:47 PM] Setting object_model -> None\n",
+      "[INFO][2022/04/20 01:59:47 PM] Setting hypothesis_model -> hypotheses=['P_FP', 'P_init', 'P_term', 'P_link', 'P_branch', 'P_dead'] lambda_time=5.0 lambda_dist=3.0 lambda_link=10.0 lambda_branch=50.0 eta=1e-10 theta_dist=20.0 theta_time=5.0 dist_thresh=40.0 time_thresh=2.0 apop_thresh=5 segmentation_miss_rate=0.1 apoptosis_rate=0.001 relax=True name='cell_hypothesis'\n",
+      "[INFO][2022/04/20 01:59:47 PM] Setting max_search_radius -> 100\n",
+      "[INFO][2022/04/20 01:59:47 PM] Setting return_kalman -> False\n",
+      "[INFO][2022/04/20 01:59:47 PM] Setting volume -> None\n",
+      "[INFO][2022/04/20 01:59:47 PM] Setting update_method -> BayesianUpdates.EXACT\n",
+      "[INFO][2022/04/20 01:59:47 PM] Setting optimizer_options -> {'tm_lim': 60000}\n",
+      "[INFO][2022/04/20 01:59:47 PM] Setting verbose -> True\n",
+      "[INFO][2022/04/20 01:59:47 PM] Setting max_search_radius -> 50\n",
+      "[INFO][2022/04/20 01:59:47 PM] Setting volume -> ((0, 1600), (0, 1200))\n",
+      "[INFO][2022/04/20 01:59:47 PM] Starting tracking... \n",
+      "[INFO][2022/04/20 01:59:47 PM] Tracking objects in frames 0 to 99 (of 500)...\n",
+      "[INFO][2022/04/20 01:59:47 PM] Tracking objects in frames 100 to 199 (of 500)...\n",
+      "[INFO][2022/04/20 01:59:48 PM] Tracking objects in frames 200 to 299 (of 500)...\n",
+      "[INFO][2022/04/20 01:59:48 PM] Tracking objects in frames 300 to 399 (of 500)...\n",
+      "[INFO][2022/04/20 01:59:48 PM] Tracking objects in frames 400 to 499 (of 500)...\n",
+      "[INFO][2022/04/20 01:59:49 PM] SUCCESS.\n",
+      "[INFO][2022/04/20 01:59:49 PM]  - Found 507 tracks in 500 frames (in 0.0s)\n",
+      "[INFO][2022/04/20 01:59:49 PM]  - Inserted 97 dummy objects to fill tracking gaps\n",
+      "[INFO][2022/04/20 01:59:49 PM] Loading hypothesis model: cell_hypothesis\n",
+      "[INFO][2022/04/20 01:59:49 PM] Calculating hypotheses (relax: True)...\n",
+      "[INFO][2022/04/20 01:59:49 PM]  - Fates.FALSE_POSITIVE: 32 (of 507)\n",
+      "[INFO][2022/04/20 01:59:49 PM]  - Fates.LINK: 98 (of 348)\n",
+      "[INFO][2022/04/20 01:59:49 PM]  - Fates.DIVIDE: 110 (of 121)\n",
+      "[INFO][2022/04/20 01:59:49 PM]  - Fates.APOPTOSIS: 1 (of 2)\n",
+      "[INFO][2022/04/20 01:59:49 PM]  - Fates.INITIALIZE_BORDER: 53 (of 97)\n",
+      "[INFO][2022/04/20 01:59:49 PM]  - Fates.INITIALIZE_FRONT: 70 (of 72)\n",
+      "[INFO][2022/04/20 01:59:49 PM]  - Fates.INITIALIZE_LAZY: 34 (of 338)\n",
+      "[INFO][2022/04/20 01:59:49 PM]  - Fates.TERMINATE_BORDER: 53 (of 91)\n",
+      "[INFO][2022/04/20 01:59:49 PM]  - Fates.TERMINATE_BACK: 182 (of 185)\n",
+      "[INFO][2022/04/20 01:59:49 PM]  - Fates.TERMINATE_LAZY: 31 (of 231)\n",
+      "[INFO][2022/04/20 01:59:49 PM]  - TOTAL: 1992 hypotheses\n",
+      "[INFO][2022/04/20 01:59:49 PM] Completed optimization with 409 tracks\n",
       "Removing tracks/obj_type_1.\n",
-      "[INFO][2022/04/11 03:42:46 PM] Ending BayesianTracker session\n"
+      "[INFO][2022/04/20 01:59:49 PM] Ending BayesianTracker session\n"
      ]
     },
     {
@@ -353,6 +436,7 @@
     "\n",
     "    # configure the tracker using a config file\n",
     "    tracker.configure_from_file(CONFIG_FILE)\n",
+    "    tracker.verbose=True\n",
     "    tracker.max_search_radius = 50\n",
     "\n",
     "    # append the objects to be tracked\n",
@@ -360,7 +444,7 @@
     "\n",
     "    # set the tracking volume\n",
     "    tracker.volume=((0, 1600), (0, 1200))\n",
-    "    \n",
+    "\n",
     "    # track them (in interactive mode)\n",
     "    tracker.track_interactive(step_size=100)\n",
     "\n",
@@ -521,17 +605,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "6a87d830",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Tracks layer 'Exported Tracks' at 0x166426130>"
+       "<Tracks layer 'Exported Tracks' at 0x169da9f70>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -576,8 +660,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "d896ee26",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TrackerConfig(name='Default', version='0.4.3', verbose=True, motion_model=MotionModel(measurements=3, states=6, A=array([[1., 0., 0., 1., 0., 0.],\n",
+       "       [0., 1., 0., 0., 1., 0.],\n",
+       "       [0., 0., 1., 0., 0., 1.],\n",
+       "       [0., 0., 0., 1., 0., 0.],\n",
+       "       [0., 0., 0., 0., 1., 0.],\n",
+       "       [0., 0., 0., 0., 0., 1.]]), H=array([[1., 0., 0., 0., 0., 0.],\n",
+       "       [0., 1., 0., 0., 0., 0.],\n",
+       "       [0., 0., 1., 0., 0., 0.]]), P=array([[ 15.,   0.,   0.,   0.,   0.,   0.],\n",
+       "       [  0.,  15.,   0.,   0.,   0.,   0.],\n",
+       "       [  0.,   0.,  15.,   0.,   0.,   0.],\n",
+       "       [  0.,   0.,   0., 150.,   0.,   0.],\n",
+       "       [  0.,   0.,   0.,   0., 150.,   0.],\n",
+       "       [  0.,   0.,   0.,   0.,   0., 150.]]), R=array([[5., 0., 0.],\n",
+       "       [0., 5., 0.],\n",
+       "       [0., 0., 5.]]), G=array([[ 7.5,  7.5,  7.5, 15. , 15. , 15. ]]), Q=array([[ 56.25,  56.25,  56.25, 112.5 , 112.5 , 112.5 ],\n",
+       "       [ 56.25,  56.25,  56.25, 112.5 , 112.5 , 112.5 ],\n",
+       "       [ 56.25,  56.25,  56.25, 112.5 , 112.5 , 112.5 ],\n",
+       "       [112.5 , 112.5 , 112.5 , 225.  , 225.  , 225.  ],\n",
+       "       [112.5 , 112.5 , 112.5 , 225.  , 225.  , 225.  ],\n",
+       "       [112.5 , 112.5 , 112.5 , 225.  , 225.  , 225.  ]]), dt=1.0, accuracy=7.5, max_lost=5, prob_not_assign=0.001, name='cell_motion'), object_model=None, hypothesis_model=HypothesisModel(hypotheses=['P_FP', 'P_init', 'P_term', 'P_link', 'P_branch', 'P_dead'], lambda_time=5.0, lambda_dist=3.0, lambda_link=10.0, lambda_branch=50.0, eta=1e-10, theta_dist=20.0, theta_time=5.0, dist_thresh=40.0, time_thresh=2.0, apop_thresh=5, segmentation_miss_rate=0.1, apoptosis_rate=0.001, relax=True, name='cell_hypothesis'), max_search_radius=50.0, return_kalman=False, volume=ImagingVolume(x=(0.0, 1600.0), y=(0.0, 1200.0), z=None), update_method=<BayesianUpdates.EXACT: 0>, optimizer_options={'tm_lim': 60000})"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cfg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cc7c380",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/examples/example_tracking_pipeline.ipynb
+++ b/examples/example_tracking_pipeline.ipynb
@@ -33,15 +33,7 @@
    "execution_count": 1,
    "id": "7adac478",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "btrack.config\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import btrack\n",
     "\n",
@@ -137,7 +129,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x12d849dc0>"
+       "<matplotlib.image.AxesImage at 0x122038d00>"
       ]
      },
      "execution_count": 6,
@@ -176,7 +168,16 @@
    "execution_count": 7,
    "id": "79c88726",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO][2022/04/21 07:51:47 AM] Localizing objects from segmentation...\n",
+      "[INFO][2022/04/21 07:52:00 AM] ...Found 52890 objects in 500 frames.\n"
+     ]
+    }
+   ],
    "source": [
     "objects = btrack.utils.segmentation_to_objects(\n",
     "    segmentation, \n",
@@ -338,66 +339,51 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO][2022/04/20 01:59:47 PM] btrack (v0.4.3) library imported\n",
-      "[INFO][2022/04/20 01:59:47 PM] Starting BayesianTracker session\n",
-      "[INFO][2022/04/20 01:59:47 PM] Setting name -> Default\n",
-      "[INFO][2022/04/20 01:59:47 PM] Setting version -> 0.4.3\n",
-      "[INFO][2022/04/20 01:59:47 PM] Setting verbose -> False\n",
-      "[INFO][2022/04/20 01:59:47 PM] Setting motion_model -> measurements=3 states=6 A=array([[1., 0., 0., 1., 0., 0.],\n",
-      "       [0., 1., 0., 0., 1., 0.],\n",
-      "       [0., 0., 1., 0., 0., 1.],\n",
-      "       [0., 0., 0., 1., 0., 0.],\n",
-      "       [0., 0., 0., 0., 1., 0.],\n",
-      "       [0., 0., 0., 0., 0., 1.]]) H=array([[1., 0., 0., 0., 0., 0.],\n",
-      "       [0., 1., 0., 0., 0., 0.],\n",
-      "       [0., 0., 1., 0., 0., 0.]]) P=array([[ 15.,   0.,   0.,   0.,   0.,   0.],\n",
-      "       [  0.,  15.,   0.,   0.,   0.,   0.],\n",
-      "       [  0.,   0.,  15.,   0.,   0.,   0.],\n",
-      "       [  0.,   0.,   0., 150.,   0.,   0.],\n",
-      "       [  0.,   0.,   0.,   0., 150.,   0.],\n",
-      "       [  0.,   0.,   0.,   0.,   0., 150.]]) R=array([[5., 0., 0.],\n",
-      "       [0., 5., 0.],\n",
-      "       [0., 0., 5.]]) G=array([[ 7.5,  7.5,  7.5, 15. , 15. , 15. ]]) Q=array([[ 56.25,  56.25,  56.25, 112.5 , 112.5 , 112.5 ],\n",
-      "       [ 56.25,  56.25,  56.25, 112.5 , 112.5 , 112.5 ],\n",
-      "       [ 56.25,  56.25,  56.25, 112.5 , 112.5 , 112.5 ],\n",
-      "       [112.5 , 112.5 , 112.5 , 225.  , 225.  , 225.  ],\n",
-      "       [112.5 , 112.5 , 112.5 , 225.  , 225.  , 225.  ],\n",
-      "       [112.5 , 112.5 , 112.5 , 225.  , 225.  , 225.  ]]) dt=1.0 accuracy=7.5 max_lost=5 prob_not_assign=0.001 name='cell_motion'\n",
-      "[INFO][2022/04/20 01:59:47 PM] Setting object_model -> None\n",
-      "[INFO][2022/04/20 01:59:47 PM] Setting hypothesis_model -> hypotheses=['P_FP', 'P_init', 'P_term', 'P_link', 'P_branch', 'P_dead'] lambda_time=5.0 lambda_dist=3.0 lambda_link=10.0 lambda_branch=50.0 eta=1e-10 theta_dist=20.0 theta_time=5.0 dist_thresh=40.0 time_thresh=2.0 apop_thresh=5 segmentation_miss_rate=0.1 apoptosis_rate=0.001 relax=True name='cell_hypothesis'\n",
-      "[INFO][2022/04/20 01:59:47 PM] Setting max_search_radius -> 100\n",
-      "[INFO][2022/04/20 01:59:47 PM] Setting return_kalman -> False\n",
-      "[INFO][2022/04/20 01:59:47 PM] Setting volume -> None\n",
-      "[INFO][2022/04/20 01:59:47 PM] Setting update_method -> BayesianUpdates.EXACT\n",
-      "[INFO][2022/04/20 01:59:47 PM] Setting optimizer_options -> {'tm_lim': 60000}\n",
-      "[INFO][2022/04/20 01:59:47 PM] Setting verbose -> True\n",
-      "[INFO][2022/04/20 01:59:47 PM] Setting max_search_radius -> 50\n",
-      "[INFO][2022/04/20 01:59:47 PM] Setting volume -> ((0, 1600), (0, 1200))\n",
-      "[INFO][2022/04/20 01:59:47 PM] Starting tracking... \n",
-      "[INFO][2022/04/20 01:59:47 PM] Tracking objects in frames 0 to 99 (of 500)...\n",
-      "[INFO][2022/04/20 01:59:47 PM] Tracking objects in frames 100 to 199 (of 500)...\n",
-      "[INFO][2022/04/20 01:59:48 PM] Tracking objects in frames 200 to 299 (of 500)...\n",
-      "[INFO][2022/04/20 01:59:48 PM] Tracking objects in frames 300 to 399 (of 500)...\n",
-      "[INFO][2022/04/20 01:59:48 PM] Tracking objects in frames 400 to 499 (of 500)...\n",
-      "[INFO][2022/04/20 01:59:49 PM] SUCCESS.\n",
-      "[INFO][2022/04/20 01:59:49 PM]  - Found 507 tracks in 500 frames (in 0.0s)\n",
-      "[INFO][2022/04/20 01:59:49 PM]  - Inserted 97 dummy objects to fill tracking gaps\n",
-      "[INFO][2022/04/20 01:59:49 PM] Loading hypothesis model: cell_hypothesis\n",
-      "[INFO][2022/04/20 01:59:49 PM] Calculating hypotheses (relax: True)...\n",
-      "[INFO][2022/04/20 01:59:49 PM]  - Fates.FALSE_POSITIVE: 32 (of 507)\n",
-      "[INFO][2022/04/20 01:59:49 PM]  - Fates.LINK: 98 (of 348)\n",
-      "[INFO][2022/04/20 01:59:49 PM]  - Fates.DIVIDE: 110 (of 121)\n",
-      "[INFO][2022/04/20 01:59:49 PM]  - Fates.APOPTOSIS: 1 (of 2)\n",
-      "[INFO][2022/04/20 01:59:49 PM]  - Fates.INITIALIZE_BORDER: 53 (of 97)\n",
-      "[INFO][2022/04/20 01:59:49 PM]  - Fates.INITIALIZE_FRONT: 70 (of 72)\n",
-      "[INFO][2022/04/20 01:59:49 PM]  - Fates.INITIALIZE_LAZY: 34 (of 338)\n",
-      "[INFO][2022/04/20 01:59:49 PM]  - Fates.TERMINATE_BORDER: 53 (of 91)\n",
-      "[INFO][2022/04/20 01:59:49 PM]  - Fates.TERMINATE_BACK: 182 (of 185)\n",
-      "[INFO][2022/04/20 01:59:49 PM]  - Fates.TERMINATE_LAZY: 31 (of 231)\n",
-      "[INFO][2022/04/20 01:59:49 PM]  - TOTAL: 1992 hypotheses\n",
-      "[INFO][2022/04/20 01:59:49 PM] Completed optimization with 409 tracks\n",
+      "[INFO][2022/04/21 07:52:01 AM] Loaded btrack: /Users/arl/Dropbox/Code/py3/BayesianTracker/btrack/libs/libtracker.dylib\n",
+      "[INFO][2022/04/21 07:52:01 AM] btrack (v0.4.3) library imported\n",
+      "[INFO][2022/04/21 07:52:01 AM] Starting BayesianTracker session\n",
+      "[INFO][2022/04/21 07:52:01 AM] Loading configuration file: /Users/arl/Library/Caches/btrack-examples/examples/cell_config.json\n",
+      "[INFO][2022/04/21 07:52:01 AM] Setting max_search_radius -> 50\n",
+      "[INFO][2022/04/21 07:52:01 AM] Setting volume -> ((0, 1600), (0, 1200))\n",
+      "[INFO][2022/04/21 07:52:01 AM] Starting tracking... \n",
+      "[INFO][2022/04/21 07:52:01 AM] Tracking objects in frames 0 to 99 (of 500)...\n",
+      "[INFO][2022/04/21 07:52:01 AM]  - Timing (Bayesian updates: 0.94ms, Linking: 0.17ms)\n",
+      "[INFO][2022/04/21 07:52:01 AM]  - Probabilities (Link: 1.00000, Lost: 0.49482)\n",
+      "[INFO][2022/04/21 07:52:01 AM]  - Stats (Active: 78, Lost: 194, Conflicts resolved: 110)\n",
+      "[INFO][2022/04/21 07:52:01 AM] Tracking objects in frames 100 to 199 (of 500)...\n",
+      "[INFO][2022/04/21 07:52:01 AM]  - Timing (Bayesian updates: 1.10ms, Linking: 0.17ms)\n",
+      "[INFO][2022/04/21 07:52:01 AM]  - Probabilities (Link: 1.00000, Lost: 0.60258)\n",
+      "[INFO][2022/04/21 07:52:01 AM]  - Stats (Active: 83, Lost: 326, Conflicts resolved: 187)\n",
+      "[INFO][2022/04/21 07:52:01 AM] Tracking objects in frames 200 to 299 (of 500)...\n",
+      "[INFO][2022/04/21 07:52:01 AM]  - Timing (Bayesian updates: 2.09ms, Linking: 0.25ms)\n",
+      "[INFO][2022/04/21 07:52:01 AM]  - Probabilities (Link: 1.00000, Lost: 0.27376)\n",
+      "[INFO][2022/04/21 07:52:01 AM]  - Stats (Active: 113, Lost: 574, Conflicts resolved: 276)\n",
+      "[INFO][2022/04/21 07:52:01 AM] Tracking objects in frames 300 to 399 (of 500)...\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Timing (Bayesian updates: 3.38ms, Linking: 0.33ms)\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Probabilities (Link: 0.99997, Lost: 0.99982)\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Stats (Active: 140, Lost: 1001, Conflicts resolved: 401)\n",
+      "[INFO][2022/04/21 07:52:02 AM] Tracking objects in frames 400 to 499 (of 500)...\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Timing (Bayesian updates: 6.29ms, Linking: 0.43ms)\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Probabilities (Link: 1.00000, Lost: 1.00000)\n",
+      "[INFO][2022/04/21 07:52:02 AM] SUCCESS.\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Found 507 tracks in 500 frames (in 0.0s)\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Inserted 97 dummy objects to fill tracking gaps\n",
+      "[INFO][2022/04/21 07:52:02 AM] Loading hypothesis model: cell_hypothesis\n",
+      "[INFO][2022/04/21 07:52:02 AM] Calculating hypotheses (relax: True)...\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Fates.FALSE_POSITIVE: 32 (of 507)\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Fates.LINK: 98 (of 348)\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Fates.DIVIDE: 110 (of 121)\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Fates.APOPTOSIS: 1 (of 2)\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Fates.INITIALIZE_BORDER: 53 (of 97)\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Fates.INITIALIZE_FRONT: 70 (of 72)\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Fates.INITIALIZE_LAZY: 34 (of 338)\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Fates.TERMINATE_BORDER: 53 (of 91)\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Fates.TERMINATE_BACK: 182 (of 185)\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - Fates.TERMINATE_LAZY: 31 (of 231)\n",
+      "[INFO][2022/04/21 07:52:02 AM]  - TOTAL: 1992 hypotheses\n",
+      "[INFO][2022/04/21 07:52:02 AM] Completed optimization with 409 tracks\n",
       "Removing tracks/obj_type_1.\n",
-      "[INFO][2022/04/20 01:59:49 PM] Ending BayesianTracker session\n"
+      "[INFO][2022/04/21 07:52:02 AM] Ending BayesianTracker session\n"
      ]
     },
     {
@@ -436,7 +422,7 @@
     "\n",
     "    # configure the tracker using a config file\n",
     "    tracker.configure_from_file(CONFIG_FILE)\n",
-    "    tracker.verbose=True\n",
+    "    tracker.verbose = True\n",
     "    tracker.max_search_radius = 50\n",
     "\n",
     "    # append the objects to be tracked\n",
@@ -612,7 +598,7 @@
     {
      "data": {
       "text/plain": [
-       "<Tracks layer 'Exported Tracks' at 0x169da9f70>"
+       "<Tracks layer 'Exported Tracks' at 0x13ff08370>"
       ]
      },
      "execution_count": 15,
@@ -697,14 +683,6 @@
    "source": [
     "cfg"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9cc7c380",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/example_tracking_pipeline.ipynb
+++ b/examples/example_tracking_pipeline.ipynb
@@ -129,7 +129,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x1462efc70>"
+       "<matplotlib.image.AxesImage at 0x13b5acdc0>"
       ]
      },
      "execution_count": 6,
@@ -189,52 +189,7 @@
    "execution_count": 8,
    "id": "370348e3",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>ID</th>\n",
-       "      <th>x</th>\n",
-       "      <th>y</th>\n",
-       "      <th>z</th>\n",
-       "      <th>t</th>\n",
-       "      <th>dummy</th>\n",
-       "      <th>states</th>\n",
-       "      <th>label</th>\n",
-       "      <th>prob</th>\n",
-       "      <th>area</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0</td>\n",
-       "      <td>517.573657</td>\n",
-       "      <td>9.07279</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0</td>\n",
-       "      <td>5</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>577</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "{'ID': 0, 'x': 517.5736568457539, 'y': 9.072790294627383, 'z': 0.0, 't': 0, 'dummy': False, 'states': 0, 'label': 5, 'prob': 0.0, 'area': 577}"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "objects[0]"
    ]
@@ -330,49 +285,36 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[WARNING][2022/04/05 11:49:49 AM] btrack (v0.4.3) shared library mismatch.\n",
-      "[INFO][2022/04/05 11:49:49 AM] Setting max XYZ search radius to: 100\n",
-      "[INFO][2022/04/05 11:49:49 AM] Starting BayesianTracker session\n",
-      "[INFO][2022/04/05 11:49:49 AM] Loading motion model: cell_motion\n",
-      "[INFO][2022/04/05 11:49:49 AM] Setting max XYZ search radius to: 50\n",
-      "[INFO][2022/04/05 11:49:49 AM] Set volume to ((0, 1600), (0, 1200), (-100000.0, 100000.0))\n",
-      "[INFO][2022/04/05 11:49:49 AM] Starting tracking... \n",
-      "[INFO][2022/04/05 11:49:49 AM] Tracking objects in frames 0 to 99 (of 500)...\n",
-      "[INFO][2022/04/05 11:49:50 AM] Tracking objects in frames 100 to 199 (of 500)...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Instantiating BTRACK interface wrapper (v0.4.3, compiled Nov 25 2021 at 11:31:42)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[INFO][2022/04/05 11:49:50 AM] Tracking objects in frames 200 to 299 (of 500)...\n",
-      "[INFO][2022/04/05 11:49:50 AM] Tracking objects in frames 300 to 399 (of 500)...\n",
-      "[INFO][2022/04/05 11:49:50 AM] Tracking objects in frames 400 to 499 (of 500)...\n",
-      "[INFO][2022/04/05 11:49:51 AM] SUCCESS.\n",
-      "[INFO][2022/04/05 11:49:51 AM]  - Found 507 tracks in 500 frames (in 0.0s)\n",
-      "[INFO][2022/04/05 11:49:51 AM]  - Inserted 97 dummy objects to fill tracking gaps\n",
-      "[INFO][2022/04/05 11:49:51 AM] Loading hypothesis model: cell_hypothesis\n",
-      "[INFO][2022/04/05 11:49:51 AM] Calculating hypotheses (relax: True)...\n",
-      "[INFO][2022/04/05 11:49:51 AM]  - Fates.FALSE_POSITIVE: 32 (of 507)\n",
-      "[INFO][2022/04/05 11:49:51 AM]  - Fates.LINK: 98 (of 348)\n",
-      "[INFO][2022/04/05 11:49:51 AM]  - Fates.DIVIDE: 110 (of 121)\n",
-      "[INFO][2022/04/05 11:49:51 AM]  - Fates.APOPTOSIS: 1 (of 2)\n",
-      "[INFO][2022/04/05 11:49:51 AM]  - Fates.INITIALIZE_BORDER: 53 (of 97)\n",
-      "[INFO][2022/04/05 11:49:51 AM]  - Fates.INITIALIZE_FRONT: 70 (of 72)\n",
-      "[INFO][2022/04/05 11:49:51 AM]  - Fates.INITIALIZE_LAZY: 34 (of 338)\n",
-      "[INFO][2022/04/05 11:49:51 AM]  - Fates.TERMINATE_BORDER: 53 (of 91)\n",
-      "[INFO][2022/04/05 11:49:51 AM]  - Fates.TERMINATE_BACK: 182 (of 185)\n",
-      "[INFO][2022/04/05 11:49:51 AM]  - Fates.TERMINATE_LAZY: 31 (of 231)\n",
-      "[INFO][2022/04/05 11:49:51 AM]  - TOTAL: 1992 hypotheses\n",
-      "[INFO][2022/04/05 11:49:51 AM] Completed optimization with 409 tracks\n",
-      "[INFO][2022/04/05 11:49:51 AM] Ending BayesianTracker session\n"
+      "[INFO][2022/04/11 03:42:44 PM] btrack (v0.4.3) library imported\n",
+      "[INFO][2022/04/11 03:42:44 PM] Starting BayesianTracker session\n",
+      "[INFO][2022/04/11 03:42:44 PM] Loading motion model: cell_motion\n",
+      "[INFO][2022/04/11 03:42:44 PM] Setting max XYZ search radius to: 50\n",
+      "[INFO][2022/04/11 03:42:44 PM] Set volume to ((0, 1600), (0, 1200), (-100000.0, 100000.0))\n",
+      "[INFO][2022/04/11 03:42:44 PM] Starting tracking... \n",
+      "[INFO][2022/04/11 03:42:44 PM] Tracking objects in frames 0 to 99 (of 500)...\n",
+      "[INFO][2022/04/11 03:42:44 PM] Tracking objects in frames 100 to 199 (of 500)...\n",
+      "[INFO][2022/04/11 03:42:44 PM] Tracking objects in frames 200 to 299 (of 500)...\n",
+      "[INFO][2022/04/11 03:42:45 PM] Tracking objects in frames 300 to 399 (of 500)...\n",
+      "[INFO][2022/04/11 03:42:45 PM] Tracking objects in frames 400 to 499 (of 500)...\n",
+      "[INFO][2022/04/11 03:42:45 PM] SUCCESS.\n",
+      "[INFO][2022/04/11 03:42:45 PM]  - Found 507 tracks in 500 frames (in 0.0s)\n",
+      "[INFO][2022/04/11 03:42:45 PM]  - Inserted 97 dummy objects to fill tracking gaps\n",
+      "[INFO][2022/04/11 03:42:45 PM] Loading hypothesis model: cell_hypothesis\n",
+      "[INFO][2022/04/11 03:42:45 PM] Calculating hypotheses (relax: True)...\n",
+      "[INFO][2022/04/11 03:42:45 PM]  - Fates.FALSE_POSITIVE: 32 (of 507)\n",
+      "[INFO][2022/04/11 03:42:45 PM]  - Fates.LINK: 98 (of 348)\n",
+      "[INFO][2022/04/11 03:42:45 PM]  - Fates.DIVIDE: 110 (of 121)\n",
+      "[INFO][2022/04/11 03:42:45 PM]  - Fates.APOPTOSIS: 1 (of 2)\n",
+      "[INFO][2022/04/11 03:42:45 PM]  - Fates.INITIALIZE_BORDER: 53 (of 97)\n",
+      "[INFO][2022/04/11 03:42:45 PM]  - Fates.INITIALIZE_FRONT: 70 (of 72)\n",
+      "[INFO][2022/04/11 03:42:45 PM]  - Fates.INITIALIZE_LAZY: 34 (of 338)\n",
+      "[INFO][2022/04/11 03:42:45 PM]  - Fates.TERMINATE_BORDER: 53 (of 91)\n",
+      "[INFO][2022/04/11 03:42:45 PM]  - Fates.TERMINATE_BACK: 182 (of 185)\n",
+      "[INFO][2022/04/11 03:42:45 PM]  - Fates.TERMINATE_LAZY: 31 (of 231)\n",
+      "[INFO][2022/04/11 03:42:45 PM]  - TOTAL: 1992 hypotheses\n",
+      "[INFO][2022/04/11 03:42:45 PM] Completed optimization with 409 tracks\n",
+      "Removing tracks/obj_type_1.\n",
+      "[INFO][2022/04/11 03:42:46 PM] Ending BayesianTracker session\n"
      ]
     },
     {
@@ -401,8 +343,7 @@
       "+   343: mip =     not found yet >=              -inf        (1; 0)\n",
       "+   343: >>>>>   8.200734509e+02 >=   8.200734509e+02   0.0% (1; 0)\n",
       "+   343: mip =   8.200734509e+02 >=     tree is empty   0.0% (0; 1)\n",
-      "INTEGER OPTIMAL SOLUTION FOUND\n",
-      "Deleting BTRACK interface wrapper\n"
+      "INTEGER OPTIMAL SOLUTION FOUND\n"
      ]
     }
    ],
@@ -418,8 +359,8 @@
     "    tracker.append(objects)\n",
     "\n",
     "    # set the tracking volume\n",
-    "    tracker.volume=((0, 1600), (0, 1200), (-1e5, 1e5))\n",
-    "\n",
+    "    tracker.volume=((0, 1600), (0, 1200))\n",
+    "    \n",
     "    # track them (in interactive mode)\n",
     "    tracker.track_interactive(step_size=100)\n",
     "\n",
@@ -427,9 +368,17 @@
     "    tracker.optimize()\n",
     "\n",
     "    # get the tracks in a format for napari visualization\n",
-    "    data, properties, graph = tracker.to_napari(ndim=2)\n",
+    "    data, properties, graph = tracker.to_napari()\n",
     "    \n",
-    "    tracks = tracker.tracks"
+    "    # store the tracks\n",
+    "    tracks = tracker.tracks\n",
+    "    \n",
+    "    # store the configuration\n",
+    "    cfg = tracker.configuration\n",
+    "    \n",
+    "    # export the track data \n",
+    "    tracker.export(\"tracks.h5\", obj_type=\"obj_type_1\")\n",
+    "    "
    ]
   },
   {
@@ -518,6 +467,52 @@
   },
   {
    "cell_type": "markdown",
+   "id": "54a87f0a",
+   "metadata": {},
+   "source": [
+    "### Export the configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "b4383997",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "btrack.config.save_config(\"test_config.json\", cfg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "191c153e",
+   "metadata": {},
+   "source": [
+    "### Reload the saved track data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "64899259",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with btrack.dataio.HDF5FileHandler(\"tracks.h5\", \"r\", obj_type=\"obj_type_1\") as hdf:\n",
+    "    new_tracks = hdf.tracks\n",
+    "    new_data, new_properties, new_graph = btrack.utils.tracks_to_napari(new_tracks, ndim=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8160cd0e",
+   "metadata": {},
+   "source": [
+    "## Visualising the data with napari"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0f544669",
    "metadata": {},
    "source": [
@@ -526,17 +521,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "48a3b4ab",
+   "execution_count": 16,
+   "id": "6a87d830",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Tracks layer 'Tracks' at 0x17ffc5940>"
+       "<Tracks layer 'Exported Tracks' at 0x166426130>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -552,11 +547,21 @@
     "    opacity=0.2,\n",
     ")\n",
     "\n",
+    "# the track data from the tracker\n",
     "viewer.add_tracks(\n",
     "    data, \n",
     "    properties=properties, \n",
     "    graph=graph, \n",
     "    name=\"Tracks\", \n",
+    "    blending=\"translucent\",\n",
+    ")\n",
+    "\n",
+    "# the track data reconstructed from the exported HDF file\n",
+    "viewer.add_tracks(\n",
+    "    new_data, \n",
+    "    properties=new_properties, \n",
+    "    graph=new_graph, \n",
+    "    name=\"Exported Tracks\", \n",
     "    blending=\"translucent\",\n",
     ")"
    ]
@@ -564,7 +569,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "047db851",
+   "id": "98515387",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d896ee26",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ h5py>=2.10.0
 matplotlib>=3.1.1
 numpy>=1.17.3
 pooch>=1.0.0
+pydantic>=1.9.0
 scikit-image>=0.16.2
 scipy>=1.3.1

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -51,7 +51,7 @@ def create_test_tracklet(track_len: int):
 def full_tracker_example(objects):
     # run the tracking
     tracker = btrack.BayesianTracker()
-    tracker.configure_from_file("./models/cell_config.json")
+    tracker.configure("./models/cell_config.json")
     tracker.append(objects)
     tracker.volume = ((0, 1600), (0, 1200), (-1e5, 1e5))
     tracker.track_interactive(step_size=100)

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -4,7 +4,9 @@ import numpy as np
 
 import btrack
 
-CONFIG_FILE = Path("./models/cell_config.json")
+CONFIG_FILE = (
+    Path(__file__).resolve().parent.parent / "models" / "cell_config.json"
+)
 
 
 def create_test_object(id=None):

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1,6 +1,10 @@
+from pathlib import Path
+
 import numpy as np
 
 import btrack
+
+CONFIG_FILE = Path("./models/cell_config.json")
 
 
 def create_test_object(id=None):
@@ -51,7 +55,7 @@ def create_test_tracklet(track_len: int):
 def full_tracker_example(objects):
     # run the tracking
     tracker = btrack.BayesianTracker()
-    tracker.configure("./models/cell_config.json")
+    tracker.configure(CONFIG_FILE)
     tracker.append(objects)
     tracker.volume = ((0, 1600), (0, 1200), (-1e5, 1e5))
     tracker.track_interactive(step_size=100)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,18 +23,18 @@ def _random_config():
 def _validate_config(
     cfg: Union[btrack.BayesianTracker, BaseModel], options: dict
 ):
-    if not options:
-        return
+    # if not isinstance(options, dict):
+    #     return
 
     for key, value in options.items():
         cfg_value = getattr(cfg, key)
 
         # takes care of recursive model definintions (i.e. MotionModel inside
         # TrackerConfig).
-        try:
-            np.testing.assert_equal(cfg_value, value)
-        except AssertionError:
+        if isinstance(cfg_value, BaseModel):
             _validate_config(cfg_value, value)
+        else:
+            np.testing.assert_equal(cfg_value, value)
 
 
 def test_config():
@@ -68,6 +68,8 @@ def test_config_tracker_setters():
     """Test configuring the tracker using setters."""
     options = _random_config()
     with btrack.BayesianTracker() as tracker:
+
+        # use the setters to apply the comfiguration
         for key, value in options.items():
             setattr(tracker, key, value)
 
@@ -103,7 +105,7 @@ def _cfg_pydantic():
 
 @pytest.mark.parametrize("get_cfg", [_cfg_file, _cfg_dict, _cfg_pydantic])
 def test_config_tracker(get_cfg):
-    """Test configuring the tracker from a file."""
+    """Test configuring the tracker from a file, dictionary or `TrackerConfig`."""
     # load motion and hypothesis models from file, and add random options
 
     cfg = get_cfg()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 import btrack
 
 
-def _random_config():
+def _random_config() -> dict:
     rng = np.random.default_rng()
     return {
         "max_search_radius": rng.uniform(1, 100),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+import pytest
+from _utils import CONFIG_FILE
+from pydantic import BaseModel
+
+import btrack
+
+
+def _random_config():
+    rng = np.random.default_rng()
+    return {
+        "max_search_radius": rng.uniform(1, 100),
+        "update_method": rng.choice(btrack.constants.BayesianUpdates),
+        "return_kalman": bool(rng.uniform(0, 2)),
+        "verbose": bool(rng.uniform(0, 2)),
+        "volume": tuple([(0, rng.uniform(1, 100)) for _ in range(3)]),
+    }
+
+
+def _validate_config(
+    cfg: Union[btrack.BayesianTracker, BaseModel], options: dict
+):
+    if not options:
+        return
+
+    for key, value in options.items():
+        cfg_value = getattr(cfg, key)
+
+        # takes care of recursive model definintions (i.e. MotionModel inside
+        # TrackerConfig).
+        try:
+            np.testing.assert_equal(cfg_value, value)
+        except AssertionError:
+            _validate_config(cfg_value, value)
+
+
+def test_config():
+    """Test creation of a TrackerConfig object."""
+    options = _random_config()
+    cfg = btrack.config.TrackerConfig(**options)
+    assert isinstance(cfg, btrack.config.TrackerConfig)
+
+    for key, value in options.items():
+        assert getattr(cfg, key) == value
+
+
+def test_export_config(tmp_path):
+    """Test exporting the config."""
+    options = _random_config()
+    cfg = btrack.config.TrackerConfig(**options)
+
+    # export it
+    tmp_cfg_file = Path(tmp_path) / "config.json"
+    btrack.config.save_config(tmp_cfg_file, cfg)
+    assert tmp_cfg_file.exists()
+
+
+def test_import_config():
+    """Test loading a config from a file."""
+    cfg = btrack.config.load_config(CONFIG_FILE)
+    assert isinstance(cfg, btrack.config.TrackerConfig)
+
+
+def test_config_tracker_setters():
+    """Test configuring the tracker using setters."""
+    options = _random_config()
+    with btrack.BayesianTracker() as tracker:
+        for key, value in options.items():
+            setattr(tracker, key, value)
+
+        # use the getters
+        _validate_config(tracker, options)
+
+        # also check the configuration
+        _validate_config(tracker.configuration, options)
+
+
+def _cfg_dict():
+    cfg = btrack.config.load_config(CONFIG_FILE)
+    options = _random_config()
+    options.update(cfg.dict())
+    assert isinstance(options, dict)
+    return options
+
+
+def _cfg_file():
+    filename = CONFIG_FILE
+    assert isinstance(filename, Path)
+    return filename
+
+
+def _cfg_pydantic():
+    cfg = btrack.config.load_config(CONFIG_FILE)
+    options = _random_config()
+    for key, value in options.items():
+        setattr(cfg, key, value)
+    assert isinstance(cfg, btrack.config.TrackerConfig)
+    return cfg
+
+
+@pytest.mark.parametrize("get_cfg", [_cfg_file, _cfg_dict, _cfg_pydantic])
+def test_config_tracker(get_cfg):
+    """Test configuring the tracker from a file."""
+    # load motion and hypothesis models from file, and add random options
+
+    cfg = get_cfg()
+
+    with btrack.BayesianTracker() as tracker:
+        tracker.configure(cfg)
+
+        # also check the configuration
+        _validate_config(tracker, tracker.configuration.dict())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Union
+from typing import Tuple, Union
 
 import numpy as np
 import pytest
@@ -40,7 +40,7 @@ def test_config():
     assert isinstance(cfg, btrack.config.TrackerConfig)
 
     for key, value in options.items():
-        assert getattr(cfg, key) == value
+        np.testing.assert_equal(getattr(cfg, key), value)
 
 
 def test_export_config(tmp_path):
@@ -74,7 +74,7 @@ def test_config_tracker_setters():
         _validate_config(tracker.configuration, options)
 
 
-def _cfg_dict():
+def _cfg_dict() -> Tuple[dict, dict]:
     cfg_raw = btrack.config.load_config(CONFIG_FILE)
     cfg = _random_config()
     cfg.update(cfg_raw.dict())
@@ -82,14 +82,14 @@ def _cfg_dict():
     return cfg, cfg
 
 
-def _cfg_file():
+def _cfg_file() -> Tuple[Path, dict]:
     filename = CONFIG_FILE
     assert isinstance(filename, Path)
     cfg = btrack.config.load_config(filename)
     return filename, cfg.dict()
 
 
-def _cfg_pydantic():
+def _cfg_pydantic() -> Tuple[btrack.config.TrackerConfig, dict]:
     cfg = btrack.config.load_config(CONFIG_FILE)
     options = _random_config()
     for key, value in options.items():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,7 @@ import btrack
 
 
 def _random_config() -> dict:
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(seed=1234)
     return {
         "max_search_radius": rng.uniform(1, 100),
         "update_method": rng.choice(btrack.constants.BayesianUpdates),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,10 +2,9 @@ import json
 
 import numpy as np
 import pytest
+from _utils import CONFIG_FILE
 
 from btrack import models, utils
-
-CONFIG_FILE = "./models/cell_config.json"
 
 
 def test_read_motion_model():


### PR DESCRIPTION
Fairly big refactor to use `pydantic` for tracker configuration.

+ [x] Add `pydantic` as dependency
+ [x] Add `TrackerConfig` class using pydantic
+ [x] Refactor configuration of `BayesianTracker` to use `TrackerConfig`. Interface (e.g. setters/getters remain the same)
+ [x] Update and improve docstrings
+ [x] Add a named tuple for the imaging volume - automatically infer 2D/3D based on length of tuple
+ [x] Add methods to load and save configurations
+ [x] Fix pytest warnings from implicit type conversion
+ [x] Update example notebook to show configuration
+ [x] Add some tests for new configuration

In terms of usage, it's either from a file:

```python

cfg = "/path/to/test_config.json"

with btrack.BayesianTracker() as tracker:
  tracker.configure(cfg)
```

from a `TrackerConfig`:

```python
# using a dict
options = {
  "max_search_radius": 100,
}
cfg = btrack.config.TrackerConfig(**options)

# or as keywords 
cfg = btrack.config.TrackerConfig(
  max_search_radius=100,
)

with btrack.BayesianTracker() as tracker:
  tracker.configure(cfg)
```

or using the traditional setters, as before:

```python
with btrack.BayesianTracker() as tracker:
  tracker.max_search_radius = 100
```

You can now also retreive the config as a single object and save it out:
```python
with btrack.BayesianTracker() as tracker:
  tracker.max_search_radius = 100
  cfg = tracker.configuration

from btrack.config import save_config
save_config("test_config.json", cfg)
```

Closes #88 