### PR TITLE
Clean up documentation and change theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ BayesianTracker has been tested with Python 3.7+ on OS X, Linux and Win10.
 #### Installing the latest stable version
 
 ```sh
-$ pip install btrack
+pip install btrack
 ```
 
 ## Installing on M1 Mac/Apple Silicon/osx-arm64
@@ -58,8 +58,7 @@ Visit [btrack documentation][docs] to learn how to use it and see other examples
 
 ### Cell tracking in time-lapse imaging data
 
-[![LineageTree](https://raw.githubusercontent.com/quantumjot/arboretum/master/examples/napari.png)](http://lowe.cs.ucl.ac.uk/cellx.html)
-*Automated cell tracking and lineage tree reconstruction*. Visualization is provided by our plugin to Napari, [arboretum](https://btrack.readthedocs.io/en/latest/user_guide/napari.html).
+ We provide integration with Napari, including a plugin for graph visualization, [arboretum](https://btrack.readthedocs.io/en/latest/user_guide/napari.html).
 
 
 [![CellTracking](http://lowe.cs.ucl.ac.uk/images/youtube.png)](https://youtu.be/EjqluvrJGCg)

--- a/btrack/_localization.py
+++ b/btrack/_localization.py
@@ -1,29 +1,13 @@
-#!/usr/bin/env python
-# ------------------------------------------------------------------------------
-# Name:     BayesianTracker
-# Purpose:  A multi object tracking library, specifically used to reconstruct
-#           tracks in crowded fields. Here we use a probabilistic network of
-#           information to perform the trajectory linking. This method uses
-#           positional and visual information for track linking.
-#
-# Authors:  Alan R. Lowe (arl) a.lowe@ucl.ac.uk
-#
-# License:  See LICENSE.md
-#
-# Created:  14/08/2014
-# ------------------------------------------------------------------------------
-
-
-__author__ = "Alan R. Lowe"
-__email__ = "code@arlowe.co.uk"
+from __future__ import annotations
 
 import inspect
 import logging
-from typing import Generator, Optional, Tuple, Union
+from typing import Generator, List, Optional, Tuple, Union
 
 import numpy as np
 from skimage.measure import label, regionprops_table
 
+from . import btypes
 from .dataio import localizations_to_objects
 
 try:
@@ -147,32 +131,27 @@ def segmentation_to_objects(
     scale: Optional[Tuple[float]] = None,
     use_weighted_centroid: bool = True,
     assign_class_ID: bool = False,
-) -> list:
-    """Convert segmentation to a set of btrack.PyTrackObject.
+) -> List[btypes.PyTrackObject]:
+    """Convert segmentation to a set of trackable objects.
 
     Parameters
     ----------
     segmentation : np.ndarray, dask.array.core.Array or Generator
         Segmentation can be provided in several different formats. Arrays should
         be ordered as T(Z)YX.
-
     intensity_image : np.ndarray, dask.array.core.Array or Generator, optional
         Intensity image with same size as segmentation, to be used to calculate
-        additional properties. See skimage.measure.regionprops for more info.
-
+        additional properties. See `skimage.measure.regionprops` for more info.
     properties : tuple of str, optional
         Properties passed to scikit-image regionprops. These additional
         properties are added as metadata to the btrack objects.
-        See skimage.measure.regionprops for more info.
-
+        See `skimage.measure.regionprops` for more info.
     scale : tuple
         A scale for each spatial dimension of the input segmentation. Defaults
         to one for all axes, and allows scaling for anisotropic imaging data.
-
     use_weighted_centroid : bool, default True
         If an intensity image has been provided, default to calculating the
-        weighted centroid. See skimage.measure.regionprops for more info.
-
+        weighted centroid. See `skimage.measure.regionprops` for more info.
     assign_class_ID : bool, default False
         If specified, assign a class label for each individual object based on
         the pixel intensity found in the mask. Requires semantic segmentation,
@@ -181,7 +160,7 @@ def segmentation_to_objects(
     Returns
     -------
     objects : list
-        A list of btrack.PyTrackObjects
+        A list of :py:meth:`btrack.btypes.PyTrackObject` trackable objects.
     """
 
     centroids = {}

--- a/btrack/btypes.py
+++ b/btrack/btypes.py
@@ -23,7 +23,7 @@ import numpy as np
 
 from . import constants, utils
 
-__all__ = ["PyTrackObject", "PyTrackingInfo", "Tracklet"]
+__all__ = ["PyTrackObject", "Tracklet"]
 
 
 class ImagingVolume(NamedTuple):

--- a/btrack/config.py
+++ b/btrack/config.py
@@ -41,16 +41,17 @@ class TrackerConfig(BaseModel):
         Flag to request the Kalman debug info when returning tracks.
     volume : Optional[ImagingVolume]
         The imaging volume as [(xlo, xhi), ..., (zlo, zhi)]. See
-        `btypes.ImagingVolume` for more details.
+        :py:meth:`btrack.btypes.ImagingVolume` for more details.
     update_method : constants.BayesianUpdates
         The method to perform the bayesian updates during tracklet linking.
-            BayesianUpdates.EXACT
+
+            * BayesianUpdates.EXACT
                 Use the exact Bayesian update method. Can be slow for systems
                 with many objects.
-            BayesianUpdates.APPROXIMATE
+            * BayesianUpdates.APPROXIMATE
                 Use the approximate Bayesian update method. Useful for systems
                 with may objects.
-            BayesianUpdates.CUDA
+            * BayesianUpdates.CUDA
                 Use the CUDA implementation of the Bayesian update method. Not
                 currently implemented.
     optimizer_options: dict

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -44,7 +44,7 @@ class BayesianTracker:
         The dummy objects inserted by the tracker.
     volume : tuple
         The imaging volume as [(xlo, xhi), ..., (zlo, zhi)]. See
-        `btypes.ImagingVolume` for more details.
+        :py:meth:`btrack.btypes.ImagingVolume` for more details.
     frame_range : tuple
         The frame range for tracking, essentially the last dimension of volume.
     lbep : List[List]

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -77,11 +77,11 @@ class BayesianTracker:
 
     The tracking algorithm assembles reliable sections of track that do not
     contain splitting events (tracklets). Each new tracklet initiates a
-    probabilistic model in the form of a Kalman filter [1], and utilises this to
+    probabilistic model in the form of a Kalman filter [1]_, and utilises this to
     predict future states (and error in states) of each of the objects in the
     field of view.  We assign new observations to the growing tracklets
     (linking) by evaluating the posterior probability of each potential linkage
-    from a Bayesian belief matrix for all possible linkages [2]. The best
+    from a Bayesian belief matrix for all possible linkages [2]_. The best
     linkages are those with the highest posterior probability.
 
     Data can be passed in in the following formats:
@@ -94,15 +94,14 @@ class BayesianTracker:
     data sets. The latter is useful if using only the first part of a tracking
     protocol, or other metadata is needed for further analysis. The references
     can be used to make symbolic links in HDF5 files, for example. Use
-    `optimise` to generate hypotheses for global optimisation [3][4]. Read the
+    `optimise` to generate hypotheses for global optimisation [3]_ [4]_. Read the
     `optimiser.TrackOptimiser` documentation for more information about the
     track linker.
 
-    Full details of the implementation can be found in [5][6].
+    Full details of the implementation can be found in [5]_ and [6]_.
 
     Examples
     --------
-
     Can be used with ContextManager support, like this:
 
         >>> with BayesianTracker() as tracker:
@@ -114,24 +113,24 @@ class BayesianTracker:
     References
     ----------
     .. [1] 'A new approach to linear filtering and prediction problems.'
-    Kalman RE, 1960 Journal of Basic Engineering
+      Kalman RE, 1960 Journal of Basic Engineering
 
     .. [2] 'A Bayesian algorithm for tracking multiple moving objects in outdoor
-    surveillance video', Narayana M and Haverkamp D 2007 IEEE
+      surveillance video', Narayana M and Haverkamp D 2007 IEEE
 
     .. [3] 'Report Automated Cell Lineage Construction' Al-Kofahi et al.
-    Cell Cycle 2006 vol. 5 (3) pp. 327-335
+      Cell Cycle 2006 vol. 5 (3) pp. 327-335
 
     .. [4] 'Reliable cell tracking by global data association', Bise et al.
-    2011 IEEE Symposium on Biomedical Imaging pp. 1004-1010
+      2011 IEEE Symposium on Biomedical Imaging pp. 1004-1010
 
     .. [5] 'Local cellular neighbourhood controls proliferation in cell
-    competition', Bove A, Gradeci D, Fujita Y, Banerjee S, Charras G and
-    Lowe AR 2017 Mol. Biol. Cell vol 28 pp. 3215-3228
+      competition', Bove A, Gradeci D, Fujita Y, Banerjee S, Charras G and
+      Lowe AR 2017 Mol. Biol. Cell vol 28 pp. 3215-3228
 
     .. [6] 'Automated deep lineage tree analysis using a Bayesian single cell
-    tracking approach', Ulicna K, Vallardi G, Charras G and Lowe AR 2021 Front.
-    Comput. Sci. 3
+      tracking approach', Ulicna K, Vallardi G, Charras G and Lowe AR 2021 Front.
+      Comput. Sci. 3
     """
 
     def __init__(
@@ -296,18 +295,25 @@ class BayesianTracker:
 
         Notes
         -----
-        L : int
-            A unique label of the track (label of markers, 16-bit positive).
-        B : int
-            A zero-based temporal index of the frame in which the track begins.
-        E : int
-            A zero-based temporal index of the frame in which the track ends.
-        P : int
-            Label of the parent track (0 is used when no parent is defined).
-        R : int
-            Label of the root track.
-        G : int
-            Generational depth (from root).
+
+        .. list-table:: LBEP table layout
+           :widths: 10 90
+           :header-rows: 1
+
+           * - Index
+             - Description
+           * - L
+             - A unique label of the track (label of markers, 16-bit positive).
+           * - B
+             - A zero-based temporal index of the frame in which the track begins.
+           * - E
+             - A zero-based temporal index of the frame in which the track ends.
+           * - P
+             - Label of the parent track (0 is used when no parent is defined).
+           * - R
+             - Label of the root track.
+           * - G
+             - Generational depth (from root).
         """
 
         def _lbep_table(t):

--- a/btrack/core.py
+++ b/btrack/core.py
@@ -1,21 +1,3 @@
-#!/usr/bin/env python
-# ------------------------------------------------------------------------------
-# Name:     BayesianTracker
-# Purpose:  A multi object tracking library, specifically used to reconstruct
-#           tracks in crowded fields. Here we use a probabilistic network of
-#           information to perform the trajectory linking. This method uses
-#           positional and visual information for track linking.
-#
-# Authors:  Alan R. Lowe (arl) a.lowe@ucl.ac.uk
-#
-# License:  See LICENSE.md
-#
-# Created:  14/08/2014
-# ------------------------------------------------------------------------------
-
-__author__ = "Alan R. Lowe"
-__email__ = "a.lowe@ucl.ac.uk"
-
 import ctypes
 import itertools
 import logging
@@ -85,9 +67,11 @@ class BayesianTracker:
     linkages are those with the highest posterior probability.
 
     Data can be passed in in the following formats:
-        - btrack PyTrackObject (defined in btypes)
-        - CSV
-        - HDF
+
+        * numpy arrays
+        * :py:meth:`btrack.btypes.PyTrackObject`
+        * CSV (see :py:meth:`btrack.dataio.import_CSV`)
+        * HDF (see :py:meth:`btrack.dataio.HDF5FileHandler`)
 
     The tracker can be used to return all of the original data neatly packaged
     into tracklet objects, or as a nested list of references to the original
@@ -95,7 +79,7 @@ class BayesianTracker:
     protocol, or other metadata is needed for further analysis. The references
     can be used to make symbolic links in HDF5 files, for example. Use
     `optimise` to generate hypotheses for global optimisation [3]_ [4]_. Read the
-    `optimiser.TrackOptimiser` documentation for more information about the
+    :py:meth:`optimiser.TrackOptimiser` documentation for more information about the
     track linker.
 
     Full details of the implementation can be found in [5]_ and [6]_.
@@ -544,6 +528,7 @@ class BayesianTracker:
         return h
 
     def optimize(self, **kwargs):
+        """Proxy for `optimise` for our American friends ;)"""
         return self.optimise(**kwargs)
 
     def optimise(
@@ -709,7 +694,7 @@ class BayesianTracker:
         ndim: Optional[int] = None,
     ) -> Tuple[np.array, dict, dict]:
         """Return the data in a format for a napari tracks layer.
-        See `utils.tracks_to_napari`."""
+        See :py:meth:`btrack.utils.tracks_to_napari`."""
 
         ndim = self.configuration.volume.ndim if ndim is None else ndim
 

--- a/btrack/libwrapper.py
+++ b/btrack/libwrapper.py
@@ -1,22 +1,3 @@
-#!/usr/bin/env python
-# -------------------------------------------------------------------------------
-# Name:     BayesianTracker
-# Purpose:  A multi object tracking library, specifically used to reconstruct
-#           tracks in crowded fields. Here we use a probabilistic network of
-#           information to perform the trajectory linking. This method uses
-#           positional and visual information for track linking.
-#
-# Authors:  Alan R. Lowe (arl) a.lowe@ucl.ac.uk
-#
-# License:  See LICENSE.md
-#
-# Created:  14/08/2014
-# -------------------------------------------------------------------------------
-
-
-__author__ = "Alan R. Lowe"
-__email__ = "a.lowe@ucl.ac.uk"
-
 import ctypes
 import logging
 import os

--- a/btrack/models.py
+++ b/btrack/models.py
@@ -37,7 +37,7 @@ def _check_symmetric(
 
 
 class MotionModel(BaseModel):
-    """The `btrack` motion model.
+    r"""The `btrack` motion model.
 
     Parameters
     ----------
@@ -80,6 +80,14 @@ class MotionModel(BaseModel):
     estimates of unknown variables that tend to be more precise than those that
     would be based on a single measurement alone.'
 
+    Predicted estimate of state:
+
+    .. math:: \hat{x}_{t\vert~t-1} = A_t \hat{x}_{t-1\vert~t-1}
+
+    Predicted estimate of covariance:
+
+    .. math:: P_{t\vert~t-1} = A_t P_{t-1\vert~t-1} A_t^{\top} + Q_t
+
     This is just a wrapper for the data with a few convenience functions
     thrown in. Matrices must be stored Fortran style, because Eigen uses
     column major and Numpy uses row major storage.
@@ -87,7 +95,7 @@ class MotionModel(BaseModel):
     References
     ----------
     .. [1] 'A new approach to linear filtering and prediction problems.'
-    Kalman RE, 1960 Journal of Basic Engineering
+      Kalman RE, 1960 Journal of Basic Engineering
     """
 
     measurements: int

--- a/btrack/models.py
+++ b/btrack/models.py
@@ -1,23 +1,3 @@
-#!/usr/bin/env python
-# -------------------------------------------------------------------------------
-# Name:     BayesianTracker
-# Purpose:  A multi object tracking library, specifically used to reconstruct
-#           tracks in crowded fields. Here we use a probabilistic network of
-#           information to perform the trajectory linking. This method uses
-#           positional and visual information for track linking.
-#
-# Authors:  Alan R. Lowe (arl) a.lowe@ucl.ac.uk
-#
-# License:  See LICENSE.md
-#
-# Created:  14/08/2014
-# -------------------------------------------------------------------------------
-
-
-__author__ = "Alan R. Lowe"
-__email__ = "code@arlowe.co.uk"
-
-
 from typing import List, Optional
 
 import numpy as np
@@ -47,8 +27,8 @@ class MotionModel(BaseModel):
         The number of measurements of the system (e.g. 3 for x, y, z).
     states : int
         The number of states of the system (typically >= measurements). The
-        standard measurements for a constant velocity model are (x, y, z, dx,
-        dy, dz), i.e. 6 in total for 3 measurements.
+        standard states for a constant velocity model are (x, y, z, dx, dy, dz),
+        i.e. 6 in total for 3 measurements.
     A : array (states, states)
         State transition matrix.
     H : array (measurements, states)

--- a/btrack/utils.py
+++ b/btrack/utils.py
@@ -1,23 +1,3 @@
-#!/usr/bin/env python
-# ------------------------------------------------------------------------------
-# Name:     BayesianTracker
-# Purpose:  A multi object tracking library, specifically used to reconstruct
-#           tracks in crowded fields. Here we use a probabilistic network of
-#           information to perform the trajectory linking. This method uses
-#           positional and visual information for track linking.
-#
-# Authors:  Alan R. Lowe (arl) a.lowe@ucl.ac.uk
-#
-# License:  See LICENSE.md
-#
-# Created:  14/08/2014
-# ------------------------------------------------------------------------------
-
-
-__author__ = "Alan R. Lowe"
-__email__ = "code@arlowe.co.uk"
-
-
 import logging
 
 import numpy as np

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -1,5 +1,5 @@
 ==============================
-Acknowledging or Citing Btrack
+Acknowledging or citing btrack
 ==============================
 
 More details of how this type of tracking approach can be applied to tracking cells in time-lapse microscopy data can be found in the following publications:

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -2,7 +2,7 @@
 Acknowledging or citing btrack
 ==============================
 
-More details of how this type of tracking approach can be applied to tracking cells in time-lapse microscopy data can be found in the following publications:
+More details of the tracking algorithm can be found in the following publication:
 
 | **Automated deep lineage tree analysis using a Bayesian single cell tracking approach**
 | Ulicna K, Vallardi G, Charras G and Lowe AR.
@@ -10,15 +10,9 @@ More details of how this type of tracking approach can be applied to tracking ce
 | |DOI-U2021|
 
 
-| **Local cellular neighbourhood controls proliferation in cell competition**
-| Bove A, Gradeci D, Fujita Y, Banerjee S, Charras G and Lowe AR.
-| *Mol. Biol. Cell* (2017)
-| |DOI-B2017|
+.. code-block:: bibtex
 
-
-::
-
-   @ARTICLE {10.3389/fcomp.2021.734559,
+   @ARTICLE {Ulicna:2021,
       AUTHOR = {Ulicna, Kristina and Vallardi, Giulia and Charras, Guillaume and Lowe, Alan R.},
       TITLE = {Automated Deep Lineage Tree Analysis Using a Bayesian Single Cell Tracking Approach},
       JOURNAL = {Frontiers in Computer Science},
@@ -30,25 +24,6 @@ More details of how this type of tracking approach can be applied to tracking ce
       ISSN = {2624-9898}
    }
 
-::
-
-   @ARTICLE {Bove07112017,
-     author = {Bove, Anna and Gradeci, Daniel and Fujita, Yasuyuki and Banerjee,
-       Shiladitya and Charras, Guillaume and Lowe, Alan R.},
-     title = {Local cellular neighborhood controls proliferation in cell competition},
-     volume = {28},
-     number = {23},
-     pages = {3215-3228},
-     year = {2017},
-     doi = {10.1091/mbc.E17-06-0368},
-     URL = {http://www.molbiolcell.org/content/28/23/3215.abstract},
-     eprint = {http://www.molbiolcell.org/content/28/23/3215.full.pdf+html},
-     journal = {Molecular Biology of the Cell}
-   }
-
-
 
 .. |DOI-U2021| image:: https://img.shields.io/badge/doi-10.3389%2Ffcomp.2021.734559-blue
    :target: https://doi.org/10.3389/fcomp.2021.734559
-.. |DOI-B2017| image:: https://img.shields.io/badge/doi-10.1091%2Fmbc.E17--06--0368-blue
-   :target: https://doi.org/10.1091/mbc.E17-06-0368

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx_panels",
     "sphinx_automodapi.automodapi",
     "numpydoc",
+    "sphinx_rtd_theme",
 ]
 
 numpydoc_show_class_members = False
@@ -55,9 +56,14 @@ exclude_patterns = ["build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "alabaster"
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+html_logo = "_static/btrack_logo.png"
+html_theme_options = {
+    "logo_only": True,
+    "display_version": False,
+}

--- a/docs/dev_guide/index.rst
+++ b/docs/dev_guide/index.rst
@@ -12,11 +12,11 @@ If you would rather install the latest development version, and/or compile direc
 
 .. code:: sh
 
-   $ git clone https://github.com/quantumjot/BayesianTracker.git
-   $ conda env create -f ./BayesianTracker/environment.yml
-   $ conda activate btrack
-   $ cd BayesianTracker
-   $ pip install -e .
+   git clone https://github.com/quantumjot/BayesianTracker.git
+   conda env create -f ./BayesianTracker/environment.yml
+   conda activate btrack
+   cd BayesianTracker
+   pip install -e .
 
 Additionally, the ``build.sh`` script will download Eigen source, run the makefile and pip install.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-Bayesian Tracker (btrack) 🔬💻's
+Bayesian Tracker (btrack) 🔬💻
 ================================
 
 |logo|
@@ -14,10 +14,6 @@ We assign new observations to the growing tracklets (linking) by evaluating the 
 The tracklets are then assembled into tracks by using multiple hypothesis testing and integer programming to identify a globally optimal solution.
 The likelihood of each hypothesis is calculated for some or all of the tracklets based on heuristics.
 The global solution identifies a sequence of high-likelihood hypotheses that accounts for all observations.
-
-| |LineageTree|
-| *Automated cell tracking and lineage tree reconstruction*.
-  Visualization is provided by our plugin to Napari, :ref:`arboretum<using Napari>`.
 
 | |CellTracking|
 | *Video of tracking, showing automatic lineage determination*
@@ -64,7 +60,5 @@ Indices and tables
 
 .. |logo| image:: /_static/btrack_logo.png
    :alt: Btrack Logo
-.. |LineageTree| image:: https://raw.githubusercontent.com/quantumjot/arboretum/master/examples/napari.png
-   :target: http://lowe.cs.ucl.ac.uk/cellx.html
 .. |CellTracking| image:: http://lowe.cs.ucl.ac.uk/images/youtube.png
    :target: https://youtu.be/EjqluvrJGCg

--- a/docs/user_guide/configuration.rst
+++ b/docs/user_guide/configuration.rst
@@ -3,118 +3,17 @@ Guide to ``btrack`` configuration parameters
 
 This is a short guide to the configuration parameters for ``btrack``
 
+Motion and Hypothesis models
+----------------------------
+
+Detailed descriptions of the parameters of the models can be found in the API documentation:
+
+* :py:meth:`btrack.models.MotionModel`
+* :py:meth:`btrack.models.HypothesisModel`
+
 Miscellaneous parameters
 ------------------------
 
 - ``max_search_radius`` - the maximum search radius in isotropic unit of the data
-- ``mode`` - the update mode for the tracker
+- ``update_mode`` - the update mode for the tracker
 - ``volume`` - estimate of the dimensions of the imaging volume
-
-Motion model
-------------
-
-.. code:: json
-
-   "MotionModel": {
-     "name": "cell_motion",
-     "dt": 1.0,
-     "measurements": 3,
-     "states": 6,
-     "accuracy": 7.5,
-     "prob_not_assign": 0.001,
-     "max_lost": 5,
-     "A": {
-       "matrix": [1,0,0,1,0,0,
-                  0,1,0,0,1,0,
-                  0,0,1,0,0,1,
-                  0,0,0,1,0,0,
-                  0,0,0,0,1,0,
-                  0,0,0,0,0,1]
-     },
-     "H": {
-       "matrix": [1,0,0,0,0,0,
-                  0,1,0,0,0,0,
-                  0,0,1,0,0,0]
-     },
-     "P": {
-       "sigma": 150.0,
-       "matrix": [0.1,0,0,0,0,0,
-                  0,0.1,0,0,0,0,
-                  0,0,0.1,0,0,0,
-                  0,0,0,1,0,0,
-                  0,0,0,0,1,0,
-                  0,0,0,0,0,1]
-     },
-     "G": {
-       "sigma": 15.0,
-       "matrix": [0.5,0.5,0.5,1,1,1]
-
-     },
-     "R": {
-       "sigma": 5.0,
-       "matrix": [1,0,0,
-                  0,1,0,
-                  0,0,1]
-     }
-   }
-
-- ``name`` - this is the name of the model
-- ``measurements`` - the number of measurements of the system (e.g. x, y, z)
-- ``states`` - the number of states of the system (typically >= measurements)
-- ``A`` - State transition matrix
-- ``B`` - Control matrix
-- ``H`` - Observation matrix
-- ``P`` - Initial covariance estimate
-- ``Q`` - Estimated error in process
-- ``R`` - Estimated error in measurements
-- ``accuracy`` - integration limits for calculating the probabilities
-- ``dt`` - time difference, always 1
-- ``max_lost`` - number of frames without observation before marking a track as lost
-- ``prob_not_assign`` - the default probability to not assign a track
-- ``sigma`` - a scalar multiplication factor used for each matrix
-
-Hypothesis model
-----------------
-
-Below is an example of a configuration for the global optimizer.
-
-.. code:: json
-
-   "HypothesisModel": {
-     "name": "cell_hypothesis",
-     "hypotheses": ["P_FP", "P_init", "P_term", "P_link", "P_branch", "P_dead"],
-     "lambda_time": 5.0,
-     "lambda_dist": 5.0,
-     "lambda_link": 5.0,
-     "lambda_branch": 5.0,
-     "eta": 1e-150,
-     "theta_dist": 5.0,
-     "theta_time": 5.0,
-     "dist_thresh": 10,
-     "time_thresh": 3,
-     "apop_thresh": 2,
-     "segmentation_miss_rate": 0.1,
-     "apoptosis_rate": 0.1,
-     "relax": false
-   }
-
-The parameters are, as follows:
-
-- ``name`` - this is the name of the model
-- ``hypotheses`` - this is a list of hypotheses to generate for the optimizer
-- ``lambda_time`` - a scaling factor for the influence of time when determining initialization or termination hypotheses
-- ``lambda_dist`` - a scaling factor for the influence of distance at the border when determining initialization or termination hypotheses
-- ``lambda_link`` - a scaling factor for the influence of track-to-track distance on linking probability
-- ``lambda_branch`` - a scaling factor for the influence of cell state and position on division (mitosis/branching) probability
-- ``eta`` - default low probability
-- ``theta_dist`` - a threshold (in pixels) for the distance from the edge of the FOV to add an initialization or termination hypothesis
-- ``theta_time`` - a threshold (in frames) for the time from the beginning or end of movie to add an initialization or termination hypothesis
-- ``dist_thresh`` - bin size for considering hypotheses
-- ``time_thresh`` - bin size for considering hypotheses
-- ``apop_thresh`` - number of apoptotic detections, counted consecutively from the back of the track, to be considered a real apoptosis
-- ``segmentation_miss_rate`` - miss rate for the segmentation, e.g. 1/100 segmentations incorrect = 0.01
-- ``apoptosis_rate`` - rate of apoptosis detections
-- ``relax`` - disables the ``theta_dist`` and ``theta_time`` thresholds to create termination and intialization hypotheses
-
-Object model
-------------

--- a/docs/user_guide/configuration.rst
+++ b/docs/user_guide/configuration.rst
@@ -1,19 +1,125 @@
 Guide to ``btrack`` configuration parameters
 ============================================
 
-This is a short guide to the configuration parameters for ``btrack``
+This is a short guide to the configuration parameters for ``btrack``.
 
-Motion and Hypothesis models
-----------------------------
+.. note::
+  Example configurations for particle or cell tracking applications can be found in the `models/` folder.
 
-Detailed descriptions of the parameters of the models can be found in the API documentation:
+
+Motion model
+------------
+
+The motion model is used to make forward predictions about the location of objects using historical information and estimates of the error in the measurements and the process.
+
+.. code:: json
+
+   "MotionModel": {
+     "name": "cell_motion",
+     "dt": 1.0,
+     "measurements": 3,
+     "states": 6,
+     "accuracy": 7.5,
+     "prob_not_assign": 0.001,
+     "max_lost": 5,
+     "A": {
+       "matrix": [1,0,0,1,0,0,
+                  0,1,0,0,1,0,
+                  0,0,1,0,0,1,
+                  0,0,0,1,0,0,
+                  0,0,0,0,1,0,
+                  0,0,0,0,0,1]
+     },
+     "H": {
+       "matrix": [1,0,0,0,0,0,
+                  0,1,0,0,0,0,
+                  0,0,1,0,0,0]
+     },
+     "P": {
+       "sigma": 150.0,
+       "matrix": [0.1,0,0,0,0,0,
+                  0,0.1,0,0,0,0,
+                  0,0,0.1,0,0,0,
+                  0,0,0,1,0,0,
+                  0,0,0,0,1,0,
+                  0,0,0,0,0,1]
+     },
+     "G": {
+       "sigma": 15.0,
+       "matrix": [0.5,0.5,0.5,1,1,1]
+
+     },
+     "R": {
+       "sigma": 5.0,
+       "matrix": [1,0,0,
+                  0,1,0,
+                  0,0,1]
+     }
+   }
+
+.. note::
+  In particular, the values of `sigma` for the matrices `P`, `G` and `R` specify the magnitude of the error in the initial estimates, the process itself and the measurements.
+
+Detailed descriptions of the other parameters of the model can be found in the API documentation:
 
 * :py:meth:`btrack.models.MotionModel`
+
+Hypothesis model
+----------------
+
+The hypothesis model is used by the global optimizer to build the final set of tracks if using the :py:meth:`btrack.BayesianTracker.optimize()` method.
+
+.. code:: json
+
+   "HypothesisModel": {
+     "name": "cell_hypothesis",
+     "hypotheses": ["P_FP", "P_init", "P_term", "P_link", "P_branch", "P_dead"],
+     "lambda_time": 5.0,
+     "lambda_dist": 5.0,
+     "lambda_link": 5.0,
+     "lambda_branch": 5.0,
+     "eta": 1e-10,
+     "theta_dist": 5.0,
+     "theta_time": 5.0,
+     "dist_thresh": 10,
+     "time_thresh": 3,
+     "apop_thresh": 2,
+     "segmentation_miss_rate": 0.1,
+     "apoptosis_rate": 0.1,
+     "relax": false
+   }
+
+.. note::
+  The `hypotheses` field contains a list of hypotheses to generate while running the global optimizer. The hypotheses can be chosen from the following options:
+
+  * `P_FP` - Hypothesis that a tracklet is a false positive detection.
+  * `P_init` - Hypothesis that a tracklet starts at the beginning of the movie or edge of the FOV.
+  * `P_term` - Hypothesis that a tracklet ends at the end of the movie or edge of the FOV.
+  * `P_link` - Hypothesis that two tracklets should be linked together.
+  * `P_branch` - Hypothesis that a tracklet can split onto two daughter tracklets.
+  * `P_dead` - Hypothesis that a tracklet terminates without leaving the FOV.
+  * `P_merge` - Hypothesis that two tracklets merge into one tracklet.
+
+  The list must contain at least `P_FP`.
+
+Detailed descriptions of the other parameters of the model can be found in the API documentation:
+
 * :py:meth:`btrack.models.HypothesisModel`
 
 Miscellaneous parameters
 ------------------------
 
-- ``max_search_radius`` - the maximum search radius in isotropic unit of the data
-- ``update_mode`` - the update mode for the tracker
-- ``volume`` - estimate of the dimensions of the imaging volume
+General tracking configuration options are detailed in :py:meth:`btrack.config.TrackerConfig`.
+
+- ``max_search_radius`` - The maximum search radius for the tracking algorithm in isotropic unit of the data. This parameter can be used to prevent very large displacements when linking objects.
+- ``update_mode`` - The update mode for the tracker. The default option considers all possible combinations of linking objects, so can be slow for very large datasets. See :ref:`update_methods` for more information.
+- ``volume`` - An estimate of the dimensions of the imaging volume, used to define the edges of the field of view for generating hypotheses and labeling tracks as lost.
+
+Tips and warnings
+-----------------
+
+.. warning::
+  The output of the tracking is very sensitive to the choice of parameter values. We suggest that you first optimize the motion model parameters, without using the optimization step (i.e. do not use :py:meth:`btrack.BayesianTracker.optimize()` initially).  Once you are satisfied with the intermediate results, proceed to optimizing the hypothesis model parameters.
+
+.. warning::
+  The global optimization step can take a very long time to complete if you have a poor choice of model parameters. By default, the optimizer will time-out after 60 seconds of attempting to solve to optimization.

--- a/docs/user_guide/large_datasets.rst
+++ b/docs/user_guide/large_datasets.rst
@@ -1,3 +1,5 @@
+.. _update_methods:
+
 ================================
 Dealing with very large datasets
 ================================

--- a/docs/user_guide/large_datasets.rst
+++ b/docs/user_guide/large_datasets.rst
@@ -1,6 +1,6 @@
-=================================
-Deadling with very large datasets
-=================================
+================================
+Dealing with very large datasets
+================================
 
 btrack supports three different methods:
 
@@ -23,7 +23,7 @@ Try turning off optimization, followed by modifying the parameters of the config
 
    with btrack.BayesianTracker() as tracker:
        # configure the tracker and change the update method
-       tracker.configure_from_file('/path/to/your/models/cell_config.json')
+       tracker.configure('/path/to/your/models/cell_config.json')
        tracker.update_method = BayesianUpdates.APPROXIMATE
        tracker.max_search_radius = 100
        ...

--- a/docs/user_guide/simple_example.rst
+++ b/docs/user_guide/simple_example.rst
@@ -30,7 +30,7 @@ This example shows ....
     # append the objects to be tracked
     tracker.append(objects)
 
-    # set the volume (Z axis volume is set very large for 2D data)
+    # set the volume (Z axis volume limits default to [-1e5, 1e5] for 2D data)
     tracker.volume = ((0, 1200), (0, 1600))
 
     # track them (in interactive mode)

--- a/docs/user_guide/simple_example.rst
+++ b/docs/user_guide/simple_example.rst
@@ -18,20 +18,20 @@ This example shows ....
   # create btrack objects (with properties) from the segmentation data
   # (you can also calculate properties, based on scikit-image regionprops)
   objects = btrack.utils.segmentation_to_objects(
-              segmentation, properties=('area', )
-            )
+    segmentation, properties=('area', )
+  )
 
   # initialise a tracker session using a context manager
   with btrack.BayesianTracker() as tracker:
 
     # configure the tracker using a config file
-    tracker.configure_from_file('/path/to/your/models/cell_config.json')
+    tracker.configure('/path/to/your/models/cell_config.json')
 
     # append the objects to be tracked
     tracker.append(objects)
 
     # set the volume (Z axis volume is set very large for 2D data)
-    tracker.volume=((0, 1200), (0, 1600), (-1e5, 1e5))
+    tracker.volume = ((0, 1200), (0, 1600))
 
     # track them (in interactive mode)
     tracker.track_interactive(step_size=100)
@@ -46,7 +46,7 @@ This example shows ....
     tracks = tracker.tracks
 
     # optional: get the data in a format for napari
-    data, properties, graph = tracker.to_napari(ndim=2)
+    data, properties, graph = tracker.to_napari()
 
 
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,3 +2,4 @@ numpydoc
 sphinx
 sphinx-automodapi
 sphinx-panels
+sphinx_rtd_theme


### PR DESCRIPTION
Adds a lot of new documentation for configuration of the tracker, API and changes the theme to `sphinx_rtd_theme` for legibility. Changes include:

+ [x] Fixes #64 
+ [x] Removes `PyTrackingInfo` from public API (this is only used internally)
+ [x] Fixes references, typos and provides more detail to models
+ [x] Changes RTD theme to be more legible
+ [x] Added more detail to the configuration page
+ [x] Small fixes to typing and docstrings for autodoc