### PR TITLE
fix inclusion of napari.yaml in wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,10 +23,6 @@ classifier =
 napari.manifest =
     btrack = btrack:napari.yaml
 
-# make sure it gets included in your package
-[options.package_data]
-btrack = napari.yaml
-
 [tox]
 isolated_build: true
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     packages=find_packages(),
-    package_data={"btrack": ["libs/libtracker*", "VERSION.txt"]},
+    package_data={"btrack": ["libs/libtracker*", "VERSION.txt", "napari.yaml"]},
     install_requires=get_install_required(),
     extras_require=extras_require,
     python_requires=">=3.6",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,9 @@ setup(
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     packages=find_packages(),
-    package_data={"btrack": ["libs/libtracker*", "VERSION.txt", "napari.yaml"]},
+    package_data={
+        "btrack": ["libs/libtracker*", "VERSION.txt", "napari.yaml"]
+    },
     install_requires=get_install_required(),
     extras_require=extras_require,
     python_requires=">=3.6",


### PR DESCRIPTION
Howdie,

Your `napari.yaml` is not getting included in your wheel due to conflicting info in setup.cfg and setup.py.

This should fix it (though, suggest moving towards an all-setup.cfg declarative config in the future... lemme know if a PR to that effect would be welcome)