### PR TITLE
Update napari hub info

### DIFF
--- a/.napari-hub/DESCRIPTION.md
+++ b/.napari-hub/DESCRIPTION.md
@@ -1,10 +1,13 @@
 [![PyPI](https://img.shields.io/pypi/v/btrack)](https://pypi.org/project/btrack)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/btrack.svg)](https://python.org)
 [![Downloads](https://pepy.tech/badge/btrack/month)](https://pepy.tech/project/btrack)
 [![Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Tests](https://github.com/quantumjot/BayesianTracker/actions/workflows/test.yml/badge.svg)](https://github.com/quantumjot/BayesianTracker/actions/workflows/test.yml)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Documentation](https://readthedocs.org/projects/btrack/badge/?version=latest)](https://btrack.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/quantumjot/BayesianTracker/branch/main/graph/badge.svg?token=QCFC9AWK0R)](https://codecov.io/gh/quantumjot/BayesianTracker)
+[![doi:10.3389/fcomp.2021.734559](https://img.shields.io/badge/doi-10.3389%2Ffcomp.2021.734559-blue)](https://doi.org/10.3389/fcomp.2021.734559)
+
 ![logo](https://btrack.readthedocs.io/en/latest/_images/btrack_logo.png)
 
 
@@ -15,3 +18,17 @@ each potential linkage from a Bayesian belief matrix for all possible
 linkages.
 
 We developed `btrack` for cell tracking in time-lapse microscopy data.
+
+![](https://raw.githubusercontent.com/lowe-lab-ucl/arboretum/master/examples/arboretum.gif)
+
+<!--
+## tutorials
+
+* https://napari.org/tutorials/tracking/cell_tracking.html
+-->
+
+
+## associated plugins
+
+* [napari-arboretum](https://www.napari-hub.org/plugins/napari-arboretum) - Napari plugin to enable track graph and lineage tree visualization.
+* [napari-btrack](https://github.com/lowe-lab-ucl/napari-btrack) - (Experimental) Napari plugin to provide a frontend GUI for `btrack`.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
             args: [--fix=lf]
           - id: requirements-txt-fixer
           - id: trailing-whitespace
+            args: [--markdown-linebreak-ext=md]
     - repo: https://gitlab.com/pycqa/flake8
       rev: 3.9.2
       hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,16 +5,19 @@ author = Alan R. Lowe
 author_email = a.lowe@ucl.ac.uk
 url = https://github.com/quantumjot/BayesianTracker
 project_urls =
-    Bug Tracker = https://github.com/quantumjot/BayesianTracker/issues
-    Documentation = https://btrack.readthedocs.io/en/stable/
-    Source Code = https://github.com/quantumjot/BayesianTracker
-    User Support = https://github.com/quantumjot/BayesianTracker/issues
+  Bug Tracker = https://github.com/quantumjot/BayesianTracker/issues
+  Documentation = https://btrack.readthedocs.io/en/stable/
+  Source Code = https://github.com/quantumjot/BayesianTracker
+  User Support = https://github.com/quantumjot/BayesianTracker/issues
 description = A framework for Bayesian multi-object tracking
 long_description = file: README.md
 classifier =
   Programming Language :: C++
   Programming Language :: Python
   Programming Language :: Python :: 3 :: Only
+  Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
   Topic :: Scientific/Engineering
   Topic :: Scientific/Engineering :: Bio-Informatics
   Topic :: Scientific/Engineering :: Image Recognition
@@ -55,7 +58,7 @@ btrack =
 
 [options.entry_points]
 napari.manifest =
-    btrack = btrack: napari.yaml
+  btrack = btrack: napari.yaml
 
 [tox]
 isolated_build: true
@@ -72,5 +75,5 @@ max-line-length = 79
 max-complexity = 18
 exclude = __init__.py|examples
 per-file-ignores =
-    # imported but unused
-    __init__.py: F401
+  # imported but unused
+  __init__.py: F401


### PR DESCRIPTION
Closes #152, also fixes some minor packaging details for napari-hub:

* Explicity defines the python versions supported (used by napari-hub)
* Adds a DOI for the btrack paper
* Adds references to `napari-arboretum` and `napari-btrack`
* Adds a line to prevent pre-commit "fixing" whitespace in markdown files, which can affect rendering