### PR TITLE
Add issues to board automatically

### DIFF
--- a/.github/workflows/update_project_board.yml
+++ b/.github/workflows/update_project_board.yml
@@ -1,0 +1,15 @@
+name: Add New Issues to Project Board
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  update-project-board:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.1
+        with:
+          project-url: https://github.com/orgs/lowe-lab-ucl/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
For this to work, we need admin access to add the `ADD_TO_PROJECT_PAT` environment variable @quantumjot 