### PR TITLE
Remove references to `BayesianTracker` in favour of `btrack`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   deploy:
     runs-on: "ubuntu-latest"
-    if: github.repository == 'quantumjot/BayesianTracker' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    if: github.repository == 'quantumjot/btrack' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
     steps:
       - name: Checkout source

--- a/.napari-hub/DESCRIPTION.md
+++ b/.napari-hub/DESCRIPTION.md
@@ -11,7 +11,7 @@
 ![logo](https://btrack.readthedocs.io/en/latest/_images/btrack_logo.png)
 
 
-BayesianTracker (`btrack`) is a multi object tracking algorithm,
+`btrack` is a multi object tracking algorithm,
 specifically used to reconstruct trajectories in crowded fields.  New
 observations are assigned to tracks by evaluating the posterior probability of
 each potential linkage from a Bayesian belief matrix for all possible

--- a/.napari-hub/DESCRIPTION.md
+++ b/.napari-hub/DESCRIPTION.md
@@ -2,10 +2,10 @@
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/btrack.svg)](https://python.org)
 [![Downloads](https://pepy.tech/badge/btrack/month)](https://pepy.tech/project/btrack)
 [![Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Tests](https://github.com/quantumjot/BayesianTracker/actions/workflows/test.yml/badge.svg)](https://github.com/quantumjot/BayesianTracker/actions/workflows/test.yml)
+[![Tests](https://github.com/quantumjot/btrack/actions/workflows/test.yml/badge.svg)](https://github.com/quantumjot/btrack/actions/workflows/test.yml)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Documentation](https://readthedocs.org/projects/btrack/badge/?version=latest)](https://btrack.readthedocs.io/en/latest/?badge=latest)
-[![codecov](https://codecov.io/gh/quantumjot/BayesianTracker/branch/main/graph/badge.svg?token=QCFC9AWK0R)](https://codecov.io/gh/quantumjot/BayesianTracker)
+[![codecov](https://codecov.io/gh/quantumjot/btrack/branch/main/graph/badge.svg?token=QCFC9AWK0R)](https://codecov.io/gh/quantumjot/btrack)
 [![doi:10.3389/fcomp.2021.734559](https://img.shields.io/badge/doi-10.3389%2Ffcomp.2021.734559-blue)](https://doi.org/10.3389/fcomp.2021.734559)
 
 ![logo](https://btrack.readthedocs.io/en/latest/_images/btrack_logo.png)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![PyPI](https://img.shields.io/pypi/v/btrack)](https://pypi.org/project/btrack)  [![Downloads](https://pepy.tech/badge/btrack/month)](https://pepy.tech/project/btrack)
 [![Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Tests](https://github.com/quantumjot/BayesianTracker/actions/workflows/test.yml/badge.svg)](https://github.com/quantumjot/BayesianTracker/actions/workflows/test.yml)
+[![Tests](https://github.com/quantumjot/btrack/actions/workflows/test.yml/badge.svg)](https://github.com/quantumjot/btrack/actions/workflows/test.yml)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Documentation](https://readthedocs.org/projects/btrack/badge/?version=latest)](https://btrack.readthedocs.io/en/latest/?badge=latest)
-[![codecov](https://codecov.io/gh/quantumjot/BayesianTracker/branch/main/graph/badge.svg?token=QCFC9AWK0R)](https://codecov.io/gh/quantumjot/BayesianTracker)
+[![codecov](https://codecov.io/gh/quantumjot/btrack/branch/main/graph/badge.svg?token=QCFC9AWK0R)](https://codecov.io/gh/quantumjot/btrack)
 
 [docs]: https://btrack.readthedocs.io/en/latest/
 [docs-dev]: https://btrack.readthedocs.io/en/latest/dev_guide/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 # Bayesian Tracker (btrack) :microscope::computer:
 
-BayesianTracker (`btrack`) is a Python library for multi object tracking, used to reconstruct trajectories in crowded fields.
+`btrack` is a Python library for multi object tracking, used to reconstruct trajectories in crowded fields.
 Here, we use a probabilistic network of information to perform the trajectory linking.
 This method uses spatial information as well as appearance information for track linking.
 
@@ -33,7 +33,7 @@ You can also --> :star: :wink:
 
 ## Installation
 
-BayesianTracker has been tested with Python 3.8+ on OS X, Linux and Win10.
+`btrack` has been tested with Python 3.8+ on OS X, Linux and Win10.
 
 
 #### Installing the latest stable version

--- a/btrack/btypes.py
+++ b/btrack/btypes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -------------------------------------------------------------------------------
-# Name:     BayesianTracker
+# Name:     btrack
 # Purpose:  A multi object tracking library, specifically used to reconstruct
 #           tracks in crowded fields. Here we use a probabilistic network of
 #           information to perform the trajectory linking. This method uses

--- a/btrack/include/bayes.h
+++ b/btrack/include/bayes.h
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/include/belief.h
+++ b/btrack/include/belief.h
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/include/defs.h
+++ b/btrack/include/defs.h
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/include/hyperbin.h
+++ b/btrack/include/hyperbin.h
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/include/hypothesis.h
+++ b/btrack/include/hypothesis.h
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/include/inference.h
+++ b/btrack/include/inference.h
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/include/manager.h
+++ b/btrack/include/manager.h
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/include/motion.h
+++ b/btrack/include/motion.h
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/include/pdf.h
+++ b/btrack/include/pdf.h
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/include/tracker.h
+++ b/btrack/include/tracker.h
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/include/tracklet.h
+++ b/btrack/include/tracklet.h
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/include/types.h
+++ b/btrack/include/types.h
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/include/updates.h
+++ b/btrack/include/updates.h
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/include/wrapper.h
+++ b/btrack/include/wrapper.h
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/napari.yaml
+++ b/btrack/napari.yaml
@@ -5,7 +5,7 @@ schema_version: 0.1.0
 contributions:
   commands:
   - id: btrack.read_btrack
-    title: Read BayesianTracker files
+    title: Read btrack files
     python_name: btrack.napari.reader:get_reader
 
   readers:

--- a/btrack/optimise/hypothesis.py
+++ b/btrack/optimise/hypothesis.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -------------------------------------------------------------------------------
-# Name:     BayesianTracker
+# Name:     btrack
 # Purpose:  A multi object tracking library, specifically used to reconstruct
 #           tracks in crowded fields. Here we use a probabilistic network of
 #           information to perform the trajectory linking. This method uses

--- a/btrack/optimise/optimiser.py
+++ b/btrack/optimise/optimiser.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -------------------------------------------------------------------------------
-# Name:     BayesianTracker
+# Name:     btrack
 # Purpose:  A multi object tracking library, specifically used to reconstruct
 #           tracks in crowded fields. Here we use a probabilistic network of
 #           information to perform the trajectory linking. This method uses

--- a/btrack/src/bayes.cc
+++ b/btrack/src/bayes.cc
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/src/belief.cu
+++ b/btrack/src/belief.cu
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/src/hyperbin.cc
+++ b/btrack/src/hyperbin.cc
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/src/hypothesis.cc
+++ b/btrack/src/hypothesis.cc
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/src/inference.cc
+++ b/btrack/src/inference.cc
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/src/interface.cc
+++ b/btrack/src/interface.cc
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/src/manager.cc
+++ b/btrack/src/manager.cc
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/src/motion.cc
+++ b/btrack/src/motion.cc
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/src/pdf.cc
+++ b/btrack/src/pdf.cc
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/src/tracker.cc
+++ b/btrack/src/tracker.cc
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/src/tracklet.cc
+++ b/btrack/src/tracklet.cc
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/btrack/src/wrapper.cc
+++ b/btrack/src/wrapper.cc
@@ -1,6 +1,6 @@
 /*
 --------------------------------------------------------------------------------
- Name:     BayesianTracker
+ Name:     btrack
  Purpose:  A multi object tracking library, specifically used to reconstruct
            tracks in crowded fields. Here we use a probabilistic network of
            information to perform the trajectory linking. This method uses

--- a/docs/dev_guide/index.rst
+++ b/docs/dev_guide/index.rst
@@ -5,7 +5,7 @@ Developer guide
 Installing the latest development version
 -----------------------------------------
 
-BayesianTracker has been tested with Python 3.8+ on OS X, Linux and Win10.
+``btrack`` has been tested with Python 3.8+ on OS X, Linux and Win10.
 The tracker and hypothesis engine are mostly written in C++ with a Python wrapper.
 
 If you would rather install the latest development version, and/or compile directly from source, you can clone and install from this repo:

--- a/docs/dev_guide/index.rst
+++ b/docs/dev_guide/index.rst
@@ -12,10 +12,10 @@ If you would rather install the latest development version, and/or compile direc
 
 .. code:: sh
 
-   git clone https://github.com/quantumjot/BayesianTracker.git
-   conda env create -f ./BayesianTracker/environment.yml
+   git clone https://github.com/quantumjot/btrack.git
+   conda env create -f ./btrack/environment.yml
    conda activate btrack
-   cd BayesianTracker
+   cd btrack
    pip install -e .
 
 Additionally, the ``build.sh`` script will download Eigen source, run the makefile and pip install.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ Bayesian Tracker (btrack) 🔬💻
 
 |logo|
 
-BayesianTracker (``btrack``) is a Python library for multi object tracking, used to reconstruct trajectories in crowded fields.
+``btrack`` is a Python library for multi object tracking, used to reconstruct trajectories in crowded fields.
 Here, we use a probabilistic network of information to perform the trajectory linking.
 This method uses spatial information as well as appearance information for track linking.
 

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -4,7 +4,7 @@
 User's Guide
 ************
 
-Welcome to the user guide for btrack.
+Welcome to the user guide for ``btrack``.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/user_guide/installation.rst
+++ b/docs/user_guide/installation.rst
@@ -7,7 +7,7 @@ Installation
 Requirements
 ============
 
-BayesianTracker has been tested with Python 3.8+ on OS X, Linux and Win10.
+btrack has been tested with Python 3.8+ on OS X, Linux and Win10.
 
 Installing Scientific Python
 ============================

--- a/docs/user_guide/simple_example.rst
+++ b/docs/user_guide/simple_example.rst
@@ -1,7 +1,7 @@
 A simple example
 ****************
 
-A simple pipeline is shown below. Others can be found in the `examples folder of the repository <https://github.com/quantumjot/BayesianTracker/tree/master/examples>`_.
+A simple pipeline is shown below. Others can be found in the `examples folder of the repository <https://github.com/quantumjot/btrack/tree/master/examples>`_.
 
 This example shows ....
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,4 @@
-BayesianTracker examples
+btrack examples
 ------------------------
 
 Example notebooks can be found in this directory.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,5 @@
 btrack examples
-------------------------
+---------------
 
 Example notebooks can be found in this directory.
 

--- a/examples/example_tracking_pipeline-features.ipynb
+++ b/examples/example_tracking_pipeline-features.ipynb
@@ -5,7 +5,7 @@
    "id": "d4937900",
    "metadata": {},
    "source": [
-    "![](https://raw.githubusercontent.com/quantumjot/BayesianTracker/main/docs/_static/btrack_logo.png)\n",
+    "![](https://raw.githubusercontent.com/quantumjot/btrack/main/docs/_static/btrack_logo.png)\n",
     "\n",
     "# Example of using btrack to track cells in timelapse microscopy data\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,10 @@ optional-dependencies.docs = [
 optional-dependencies.napari = [
     "napari>=0.4.16",
 ]
-urls.bugtracker = "https://github.com/quantumjot/BayesianTracker/issues"
+urls.bugtracker = "https://github.com/quantumjot/btrack/issues"
 urls.documentation = "https://btrack.readthedocs.io"
-urls.homepage = "https://github.com/quantumjot/BayesianTracker"
-urls.usersupport = "https://github.com/quantumjot/BayesianTracker/discussions"
+urls.homepage = "https://github.com/quantumjot/btrack"
+urls.usersupport = "https://github.com/quantumjot/btrack/discussions"
 
 [tool.black]
 exclude = '''


### PR DESCRIPTION
Fixes #203. We should make sure we really check this across all services.

As a minimum, we want to change the repo name and links. It would then also make sense to refer to `btrack` instead in the docs etc., but this isn't essential.

@quantumjot ultimately to merge when ready and change the repo name.